### PR TITLE
fix: clear currently tracked keyboard shortcut on visibility change

### DIFF
--- a/src/Arkanis.Overlay.Application/Program.cs
+++ b/src/Arkanis.Overlay.Application/Program.cs
@@ -83,7 +83,7 @@ public static class Program
                 services.AddSingleton<IServiceProvider>(sp => sp);
                 services.AddHttpClient();
 
-                services.AddKeyboardProxyService();
+                services.AddGlobalKeyboardProxyService();
                 services.AddJavaScriptEventInterop();
                 services.AddSingleton(typeof(WindowProvider<>));
 

--- a/src/Arkanis.Overlay.Application/Services/WindowsOverlayControls.cs
+++ b/src/Arkanis.Overlay.Application/Services/WindowsOverlayControls.cs
@@ -1,20 +1,24 @@
 namespace Arkanis.Overlay.Application.Services;
 
 using Domain.Abstractions.Services;
-using Helpers;
 using UI.Windows;
 
-public class WindowsOverlayControls(BlurHelper blurHelper) : IOverlayControls
+public class WindowsOverlayControls : IOverlayControls
 {
+    public event EventHandler? OverlayShown;
+    public event EventHandler? OverlayHidden;
+
     public ValueTask ShowAsync()
     {
         OverlayWindow.Instance?.Show();
+        OverlayShown?.Invoke(this, EventArgs.Empty);
         return ValueTask.CompletedTask;
     }
 
     public ValueTask HideAsync()
     {
         OverlayWindow.Instance?.Hide();
+        OverlayHidden?.Invoke(this, EventArgs.Empty);
         return ValueTask.CompletedTask;
     }
 

--- a/src/Arkanis.Overlay.Components/Helpers/KeyboardShortcutBuilder.cs
+++ b/src/Arkanis.Overlay.Components/Helpers/KeyboardShortcutBuilder.cs
@@ -8,13 +8,13 @@ public sealed class KeyboardShortcutBuilder : IDisposable
 {
     private readonly Func<KeyboardShortcut, Task> _completionCallback;
     private readonly Timer? _finalizeTimer;
-    private readonly Func<KeyboardShortcut, Task> _changeCallback;
 
     private readonly List<KeyboardKey> _releasedKeys = [];
+    private readonly Func<KeyboardShortcut, Task> _timeoutCallback;
 
-    public KeyboardShortcutBuilder(Func<KeyboardShortcut, Task> changeCallback, Func<KeyboardShortcut, Task> completionCallback)
+    public KeyboardShortcutBuilder(Func<KeyboardShortcut, Task> timeoutCallback, Func<KeyboardShortcut, Task> completionCallback)
     {
-        _changeCallback = changeCallback;
+        _timeoutCallback = timeoutCallback;
         _completionCallback = completionCallback;
         _finalizeTimer = new Timer(FinalizeAsync, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
     }
@@ -114,7 +114,7 @@ public sealed class KeyboardShortcutBuilder : IDisposable
         if (AreAnyKeysPressed())
         {
             ClearReleasedKeysFromKeyPress();
-            await _changeCallback.Invoke(Value);
+            await _timeoutCallback.Invoke(Value);
             return;
         }
 

--- a/src/Arkanis.Overlay.Components/Services/Abstractions/IKeyboardProxy.cs
+++ b/src/Arkanis.Overlay.Components/Services/Abstractions/IKeyboardProxy.cs
@@ -1,0 +1,14 @@
+namespace Arkanis.Overlay.Components.Services.Abstractions;
+
+using Arkanis.Overlay.Domain.Models.Keyboard;
+using Microsoft.AspNetCore.Components.Web;
+
+public interface IKeyboardProxy
+{
+    event EventHandler<KeyboardKey> OnKeyUp;
+    event EventHandler<KeyboardKey> OnKeyDown;
+    event EventHandler<KeyboardShortcut> OnKeyboardShortcut;
+
+    void RegisterKeyUp(KeyboardEventArgs keyboardEvent);
+    void RegisterKeyDown(KeyboardEventArgs keyboardEvent);
+}

--- a/src/Arkanis.Overlay.Components/Services/DependencyInjection.cs
+++ b/src/Arkanis.Overlay.Components/Services/DependencyInjection.cs
@@ -1,9 +1,10 @@
 namespace Arkanis.Overlay.Components.Services;
 
+using Abstractions;
 using Microsoft.Extensions.DependencyInjection;
 
 public static class DependencyInjection
 {
-    public static IServiceCollection AddKeyboardProxyService(this IServiceCollection services)
-        => services.AddScoped<KeyboardProxy>();
+    public static IServiceCollection AddGlobalKeyboardProxyService(this IServiceCollection services)
+        => services.AddScoped<IKeyboardProxy, GlobalOverlayKeyboardProxy>();
 }

--- a/src/Arkanis.Overlay.Components/Services/GlobalOverlayKeyboardProxy.cs
+++ b/src/Arkanis.Overlay.Components/Services/GlobalOverlayKeyboardProxy.cs
@@ -1,0 +1,28 @@
+namespace Arkanis.Overlay.Components.Services;
+
+using Domain.Abstractions.Services;
+using Microsoft.Extensions.Logging;
+
+public class GlobalOverlayKeyboardProxy : KeyboardProxy
+{
+    private readonly IOverlayControls _overlay;
+
+    public GlobalOverlayKeyboardProxy(IOverlayControls overlay, ILogger<GlobalOverlayKeyboardProxy> logger) : base(logger)
+    {
+        _overlay = overlay;
+        _overlay.OverlayShown += OnOverlayVisibilityChanged;
+        _overlay.OverlayHidden += OnOverlayVisibilityChanged;
+    }
+
+    private void OnOverlayVisibilityChanged(object? sender, EventArgs e)
+        => ShortcutBuilder.Clear();
+
+    public override void Dispose()
+    {
+        _overlay.OverlayShown -= OnOverlayVisibilityChanged;
+        _overlay.OverlayHidden -= OnOverlayVisibilityChanged;
+
+        base.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Arkanis.Overlay.Components/Services/KeyboardProxy.cs
+++ b/src/Arkanis.Overlay.Components/Services/KeyboardProxy.cs
@@ -1,53 +1,83 @@
 namespace Arkanis.Overlay.Components.Services;
 
+using Abstractions;
 using Domain.Models.Keyboard;
+using Extensions;
 using Helpers;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
-public sealed class KeyboardProxy : IDisposable
+public class KeyboardProxy : IDisposable, IKeyboardProxy
 {
-    private readonly KeyboardShortcutBuilder _shortcutBuilder;
+    private readonly ILogger _logger;
 
-    public KeyboardProxy()
-        => _shortcutBuilder = new KeyboardShortcutBuilder(
+    protected KeyboardProxy(ILogger logger)
+    {
+        _logger = logger;
+        ShortcutBuilder = new KeyboardShortcutBuilder(
             _ => Task.CompletedTask,
             _ =>
             {
-                _shortcutBuilder?.Clear();
+                ShortcutBuilder?.Clear();
                 return Task.CompletedTask;
             }
         )
         {
             FinalizationTimeout = TimeSpan.Zero,
         };
+    }
 
-    public void Dispose()
-        => _shortcutBuilder.Dispose();
+    public KeyboardProxy(ILogger<KeyboardProxy> logger) : this(logger as ILogger)
+    {
+    }
+
+    public KeyboardProxy() : this(NullLogger<KeyboardProxy>.Instance)
+    {
+    }
+
+    protected KeyboardShortcutBuilder ShortcutBuilder { get; }
+
+    public virtual void Dispose()
+    {
+        ShortcutBuilder.Dispose();
+        GC.SuppressFinalize(this);
+    }
 
     public event EventHandler<KeyboardKey>? OnKeyUp;
     public event EventHandler<KeyboardKey>? OnKeyDown;
     public event EventHandler<KeyboardShortcut>? OnKeyboardShortcut;
 
-    public void RegisterKeyUp(KeyboardKey keyboardKey)
+    public void RegisterKeyUp(KeyboardEventArgs keyboardEvent)
     {
+        var keyboardKey = keyboardEvent.GetKey();
         OnKeyUp?.Invoke(this, keyboardKey);
-        StripShortcut(keyboardKey);
+        StripShortcut(keyboardEvent);
     }
 
-    public void RegisterKeyDown(KeyboardKey keyboardKey)
+    public void RegisterKeyDown(KeyboardEventArgs keyboardEvent)
     {
+        var keyboardKey = keyboardEvent.GetKey();
         OnKeyDown?.Invoke(this, keyboardKey);
-        ExtendShortcut(keyboardKey);
+        ExtendShortcut(keyboardEvent);
     }
 
     private void RegisterKeyboardShortcut(KeyboardShortcut keyboardShortcut)
-        => OnKeyboardShortcut?.Invoke(this, keyboardShortcut);
-
-    private void ExtendShortcut(KeyboardKey keyboardKey)
     {
-        _shortcutBuilder.AddKey(keyboardKey);
-        RegisterKeyboardShortcut(_shortcutBuilder.Value.Copy());
+        if (keyboardShortcut.PressedKeys.Count > 1)
+        {
+            _logger.LogDebug("KeyboardShortcut: {KeyboardShortcut}", keyboardShortcut.Description);
+        }
+
+        OnKeyboardShortcut?.Invoke(this, keyboardShortcut);
     }
 
-    private void StripShortcut(KeyboardKey keyboardKey)
-        => _shortcutBuilder.RemoveKey(keyboardKey);
+    private void ExtendShortcut(KeyboardEventArgs keyboardEvent)
+    {
+        ShortcutBuilder.AddKey(keyboardEvent);
+        RegisterKeyboardShortcut(ShortcutBuilder.Value.Copy());
+    }
+
+    private void StripShortcut(KeyboardEventArgs keyboardEvent)
+        => ShortcutBuilder.RemoveKey(keyboardEvent);
 }

--- a/src/Arkanis.Overlay.Components/Shared/GlobalKeyboardEventProxyProvider.razor
+++ b/src/Arkanis.Overlay.Components/Shared/GlobalKeyboardEventProxyProvider.razor
@@ -1,14 +1,14 @@
 @using Arkanis.Overlay.Components.Extensions
-@using Arkanis.Overlay.Components.Services
+@using Arkanis.Overlay.Components.Services.Abstractions
 @using Microsoft.Extensions.Logging
 @using Microsoft.JSInterop
 @implements IAsyncDisposable
 @inject IJSRuntime JsRuntime
 @inject IDialogService DialogService
-@inject KeyboardProxy KeyboardProxy
+@inject IKeyboardProxy GlobalKeyboardProxy
 @inject ILogger<GlobalKeyboardEventProxyProvider> Logger
 
-<CascadingValue Value="@KeyboardProxy" IsFixed>
+<CascadingValue Value="@GlobalKeyboardProxy" IsFixed>
     @ChildContent
 </CascadingValue>
 
@@ -59,7 +59,9 @@
             return;
         }
 
-        KeyboardProxy.RegisterKeyDown(keyboardEvent.GetKey());
+        var keyboardKey = keyboardEvent.GetKey();
+        Logger.LogDebug("KeyDown: {Key}", keyboardKey);
+        GlobalKeyboardProxy.RegisterKeyDown(keyboardEvent);
     }
 
     [JSInvokable]
@@ -70,7 +72,7 @@
             return;
         }
 
-        KeyboardProxy.RegisterKeyUp(keyboardEvent.GetKey());
+        GlobalKeyboardProxy.RegisterKeyUp(keyboardEvent);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Arkanis.Overlay.Components/Shared/KeyboardEventProxyProvider.razor
+++ b/src/Arkanis.Overlay.Components/Shared/KeyboardEventProxyProvider.razor
@@ -1,5 +1,4 @@
 @using Arkanis.Overlay.Components.Services
-@using Arkanis.Overlay.Domain.Models.Keyboard
 <CascadingValue Value="@KeyboardProxy" IsFixed>
     <KeyboardInterceptor OnKeyDown="@OnKeyPress">
         @ChildContent
@@ -16,7 +15,7 @@
     [Parameter]
     public KeyboardProxy KeyboardProxy { get; set; } = new();
 
-    private void OnKeyPress(KeyboardKey keyboardKey)
-        => KeyboardProxy.RegisterKeyDown(keyboardKey);
+    private void OnKeyPress(KeyboardEventArgs keyboardEvent)
+        => KeyboardProxy.RegisterKeyDown(keyboardEvent);
 
 }

--- a/src/Arkanis.Overlay.Components/Shared/KeyboardInterceptor.razor
+++ b/src/Arkanis.Overlay.Components/Shared/KeyboardInterceptor.razor
@@ -1,5 +1,3 @@
-@using Arkanis.Overlay.Components.Extensions
-@using Arkanis.Overlay.Domain.Models.Keyboard
 <div @onkeyup="@ProcessKeyUp"
      @onkeyup:stopPropagation="@StopPropagation"
      @onkeyup:preventDefault="@PreventDefault"
@@ -17,10 +15,10 @@
     public required RenderFragment ChildContent { get; set; }
 
     [Parameter]
-    public EventCallback<KeyboardKey> OnKeyUp { get; set; }
+    public EventCallback<KeyboardEventArgs> OnKeyUp { get; set; }
 
     [Parameter]
-    public EventCallback<KeyboardKey> OnKeyDown { get; set; }
+    public EventCallback<KeyboardEventArgs> OnKeyDown { get; set; }
 
     [Parameter]
     public bool StopPropagation { get; set; }
@@ -29,9 +27,9 @@
     public bool PreventDefault { get; set; }
 
     private async Task ProcessKeyUp(KeyboardEventArgs eventArgs)
-        => await OnKeyUp.InvokeAsync(eventArgs.GetKey());
+        => await OnKeyUp.InvokeAsync(eventArgs);
 
     private async Task ProcessKeyDown(KeyboardEventArgs eventArgs)
-        => await OnKeyDown.InvokeAsync(eventArgs.GetKey());
+        => await OnKeyDown.InvokeAsync(eventArgs);
 
 }

--- a/src/Arkanis.Overlay.Components/Shared/KeyboardShortcutBadge.razor
+++ b/src/Arkanis.Overlay.Components/Shared/KeyboardShortcutBadge.razor
@@ -1,7 +1,7 @@
-@using Arkanis.Overlay.Components.Services
+@using Arkanis.Overlay.Components.Services.Abstractions
 @using Arkanis.Overlay.Domain.Models.Keyboard
 @implements IDisposable
-@inject KeyboardProxy GlobalKeyboardProxy
+@inject IKeyboardProxy GlobalKeyboardProxy
 
 <MudBadge Origin="@Origin"
           Content="@_shortcut.Description"
@@ -35,7 +35,7 @@
     public required RenderFragment ChildContent { get; set; }
 
     [Parameter]
-    public KeyboardProxy? KeyboardEventProxy { get; set; }
+    public IKeyboardProxy? KeyboardEventProxy { get; set; }
 
     [Parameter]
     public string? Class { get; set; }
@@ -58,7 +58,7 @@
     [Parameter]
     public bool DoNotOverlap { get; set; }
 
-    private KeyboardProxy UsedKeyboardProxy
+    private IKeyboardProxy UsedKeyboardProxy
         => KeyboardEventProxy ?? GlobalKeyboardProxy;
 
     protected override void OnInitialized()

--- a/src/Arkanis.Overlay.Domain/Abstractions/Services/IOverlayControls.cs
+++ b/src/Arkanis.Overlay.Domain/Abstractions/Services/IOverlayControls.cs
@@ -2,6 +2,9 @@ namespace Arkanis.Overlay.Domain.Abstractions.Services;
 
 public interface IOverlayControls
 {
+    event EventHandler OverlayShown;
+    event EventHandler OverlayHidden;
+
     ValueTask ShowAsync();
     ValueTask HideAsync();
 

--- a/src/Arkanis.Overlay.Host.Server/Program.cs
+++ b/src/Arkanis.Overlay.Host.Server/Program.cs
@@ -31,7 +31,7 @@ builder.Services.AddMudServices(options =>
 
 builder.Services
     .AddJavaScriptEventInterop()
-    .AddKeyboardProxyService()
+    .AddGlobalKeyboardProxyService()
     .AddServerOverlayControls()
     .AddInfrastructure()
     .AddInfrastructureConfiguration(builder.Configuration)

--- a/src/Arkanis.Overlay.Host.Server/Services/WebOverlayControls.cs
+++ b/src/Arkanis.Overlay.Host.Server/Services/WebOverlayControls.cs
@@ -20,6 +20,9 @@ public sealed class WebOverlayControls : IOverlayControls, IDisposable
     public void Dispose()
         => _preferencesProvider.ApplyPreferences -= ApplyUserPreferencesAsync;
 
+    public event EventHandler? OverlayShown;
+    public event EventHandler? OverlayHidden;
+
     public ValueTask ShowAsync()
     {
         _snackbar.Add(
@@ -29,6 +32,7 @@ public sealed class WebOverlayControls : IOverlayControls, IDisposable
                 options.ShowCloseIcon = false;
             }
         );
+        OverlayShown?.Invoke(this, EventArgs.Empty);
         return ValueTask.CompletedTask;
     }
 
@@ -41,6 +45,7 @@ public sealed class WebOverlayControls : IOverlayControls, IDisposable
                 options.ShowCloseIcon = false;
             }
         );
+        OverlayHidden?.Invoke(this, EventArgs.Empty);
         return ValueTask.CompletedTask;
     }
 


### PR DESCRIPTION
Resolves #98 

Added events to notify consumers when the overlay shows/disappears. This is necessary because some keyboard events (key up) disappear once the overlay is hidden due to a key press. If overlay is hidden it might become unnecessary to do various things, including tracking in-overlay keyboard shortcuts.