### PR TITLE
fix: prevent double page rendering on page refresh

### DIFF
--- a/src/Arkanis.Overlay.Host.Desktop/UI/Pages/OverlayPage.razor
+++ b/src/Arkanis.Overlay.Host.Desktop/UI/Pages/OverlayPage.razor
@@ -1,4 +1,4 @@
 @page "/overlay"
 @layout OverlayLayout
 
-<OverlayView/>
+<OverlayView @rendermode="@(new InteractiveServerRenderMode(false))"/>

--- a/src/Arkanis.Overlay.Host.Server/Components/Pages/Overlay.razor
+++ b/src/Arkanis.Overlay.Host.Server/Components/Pages/Overlay.razor
@@ -12,7 +12,7 @@
     }
 </style>
 
-<OverlayView/>
+<OverlayView @rendermode="@(new InteractiveServerRenderMode(false))"/>
 
 @code
 {


### PR DESCRIPTION
Resolves #181 

- use rendering mode without pre-render for the overlay