### PR TITLE
WIP: style: apply dotnet format

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -71,6 +71,7 @@ dotnet_style_prefer_inferred_tuple_names = true:warning
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
 dotnet_style_prefer_auto_properties = true:warning
 dotnet_style_prefer_conditional_expression_over_assignment = false:suggestion
+dotnet_diagnostic.ca1822.severity = suggestion
 dotnet_diagnostic.ide0045.severity = suggestion
 dotnet_style_prefer_conditional_expression_over_return = false:suggestion
 dotnet_diagnostic.ide0046.severity = suggestion

--- a/src/Arkanis.Overlay.Common/Abstractions/ISelfBindableOptions.cs
+++ b/src/Arkanis.Overlay.Common/Abstractions/ISelfBindableOptions.cs
@@ -8,12 +8,5 @@ public interface ISelfBindableOptions
 
     void Bind(IConfiguration configuration)
         => configuration.GetSection(SectionPath)
-            .Bind
-            (
-                this,
-                opts =>
-                {
-                    opts.ErrorOnUnknownConfiguration = true;
-                }
-            );
+            .Bind(this, opts => opts.ErrorOnUnknownConfiguration = true);
 }

--- a/src/Arkanis.Overlay.Components/Helpers/IconPicker.cs
+++ b/src/Arkanis.Overlay.Components/Helpers/IconPicker.cs
@@ -19,7 +19,7 @@ public class IconPicker : IIconPicker
             PriceType.Buy => Icons.Material.Outlined.AddShoppingCart,
             PriceType.Sell => Icons.Material.Outlined.RemoveShoppingCart,
             PriceType.Rent => Icons.Material.Outlined.CarRental,
-            _ => DefaultIcon,
+            PriceType.Undefined or _ => DefaultIcon,
         };
 
     public static string PickIconFor(GameEntityCategory value)
@@ -32,7 +32,9 @@ public class IconPicker : IIconPicker
             GameEntityCategory.ProductCategory => Icons.Material.Outlined.Topic,
             GameEntityCategory.Company => Icons.Material.Outlined.Domain,
             GameEntityCategory.Location => Icons.Material.Outlined.Public,
-            _ => DefaultIcon,
+            GameEntityCategory.ItemTrait => Icons.Material.Outlined.Label,
+            GameEntityCategory.Price => Icons.Material.Outlined.Sell,
+            GameEntityCategory.Undefined or _ => DefaultIcon,
         };
 
     public static string PickIconFor<T>(T value)

--- a/src/Arkanis.Overlay.Domain/Models/Keyboard/KeyboardKeyUtils.cs
+++ b/src/Arkanis.Overlay.Domain/Models/Keyboard/KeyboardKeyUtils.cs
@@ -30,7 +30,12 @@ public static class KeyboardKeyUtils
 
     private static readonly HashSet<KeyboardKey> EditingKeys =
     [
-        KeyboardKey.Backspace, KeyboardKey.Delete, KeyboardKey.Insert, KeyboardKey.Enter, KeyboardKey.Tab, KeyboardKey.Escape,
+        KeyboardKey.Backspace,
+        KeyboardKey.Delete,
+        KeyboardKey.Insert,
+        KeyboardKey.Enter,
+        KeyboardKey.Tab,
+        KeyboardKey.Escape,
     ];
 
     private static readonly HashSet<KeyboardKey> FunctionKeys =

--- a/src/Arkanis.Overlay.Host.Desktop/AssemblyInfo.cs
+++ b/src/Arkanis.Overlay.Host.Desktop/AssemblyInfo.cs
@@ -3,9 +3,9 @@ using System.Windows;
 [assembly: ThemeInfo
 (
     ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
-    //(used if a resource is not found in the page,
-    // or application resource dictionaries)
+                                     //(used if a resource is not found in the page,
+                                     // or application resource dictionaries)
     ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
-    //(used if a resource is not found in the page,
-    // app, or any theme specific resource dictionaries)
+                                              //(used if a resource is not found in the page,
+                                              // app, or any theme specific resource dictionaries)
 )]

--- a/src/Arkanis.Overlay.Host.Desktop/Helpers/BlurHelper.cs
+++ b/src/Arkanis.Overlay.Host.Desktop/Helpers/BlurHelper.cs
@@ -3,9 +3,9 @@ namespace Arkanis.Overlay.Host.Desktop.Helpers;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Windows.Interop;
-using Windows.Win32.Foundation;
 using Microsoft.Extensions.Logging;
 using UI.Windows;
+using Windows.Win32.Foundation;
 
 /// <summary>
 ///     Helper class for setting window composition attributes to enable blur effects.

--- a/src/Arkanis.Overlay.Host.Desktop/Helpers/WindowsKeyMap.cs
+++ b/src/Arkanis.Overlay.Host.Desktop/Helpers/WindowsKeyMap.cs
@@ -1,7 +1,7 @@
 namespace Arkanis.Overlay.Host.Desktop.Helpers;
 
-using Windows.Win32.UI.Input.KeyboardAndMouse;
 using Domain.Models.Keyboard;
+using Windows.Win32.UI.Input.KeyboardAndMouse;
 
 public static class WindowsKeyMap
 {

--- a/src/Arkanis.Overlay.Host.Desktop/PInvoke.cs
+++ b/src/Arkanis.Overlay.Host.Desktop/PInvoke.cs
@@ -47,12 +47,15 @@ internal partial class PInvoke
         var length = GetWindowTextLength(hWnd);
         Span<char> windowText = stackalloc char[length];
         GetWindowText(hWnd, windowText);
-        return SpanToString(windowText, length-1); // ignore trailing null terminator
+        return SpanToString(windowText, length - 1); // ignore trailing null terminator
     }
 
     public static bool IsTopLevelWindow(HWND hWnd)
     {
-        if (hWnd == HWND.Null) { return false; }
+        if (hWnd == HWND.Null)
+        {
+            return false;
+        }
 
         return GetAncestor(hWnd, GET_ANCESTOR_FLAGS.GA_ROOT) == hWnd;
     }
@@ -81,7 +84,10 @@ internal partial class PInvoke
 
     private static string? SpanToString(Span<char> buffer, uint length)
     {
-        if (length == 0 || buffer.IsEmpty) { return null; }
+        if (length == 0 || buffer.IsEmpty)
+        {
+            return null;
+        }
 
         // we do not need to check for overflow here
         // because `buffer.Length` is always less than or equal to `Int32.MaxValue`.
@@ -96,7 +102,10 @@ internal partial class PInvoke
 
     private static string? SpanToString(Span<char> buffer, int length)
     {
-        if (length == 0 || buffer.IsEmpty) { return null; }
+        if (length == 0 || buffer.IsEmpty)
+        {
+            return null;
+        }
 
         var safeLength = Math.Min(buffer.Length, length);
 

--- a/src/Arkanis.Overlay.Host.Desktop/Services/WindowsNotifications.cs
+++ b/src/Arkanis.Overlay.Host.Desktop/Services/WindowsNotifications.cs
@@ -1,13 +1,13 @@
 namespace Arkanis.Overlay.Host.Desktop.Services;
 
 using System.Globalization;
-using Windows.Foundation.Collections;
-using Windows.UI.Notifications;
 using Domain.Options;
 using Helpers;
 using Microsoft.Toolkit.Uwp.Notifications;
 using NuGet.Versioning;
 using Velopack;
+using Windows.Foundation.Collections;
+using Windows.UI.Notifications;
 
 internal class WindowsNotifications : IDisposable
 {

--- a/src/Arkanis.Overlay.Host.Desktop/UI/App.xaml.cs
+++ b/src/Arkanis.Overlay.Host.Desktop/UI/App.xaml.cs
@@ -1,13 +1,13 @@
-﻿namespace Arkanis.Overlay.Host.Desktop.UI;
+namespace Arkanis.Overlay.Host.Desktop.UI;
 
 using System.Diagnostics;
 using System.IO;
 using System.Windows;
-using Windows;
 using Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Windows;
 
 /// <summary>
 ///     Interaction logic for Overlay.xaml

--- a/src/Arkanis.Overlay.Host.Desktop/UI/Windows/OverlayWindow.xaml.cs
+++ b/src/Arkanis.Overlay.Host.Desktop/UI/Windows/OverlayWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using static Windows.Win32.PInvoke;
+using static Windows.Win32.PInvoke;
 
 namespace Arkanis.Overlay.Host.Desktop.UI.Windows;
 
@@ -55,7 +55,7 @@ public partial class OverlayWindow
         SetupWorkerEventListeners();
         InitializeComponent();
 
-        Height =_windowTracker.CurrentWindowSize.Height;
+        Height = _windowTracker.CurrentWindowSize.Height;
         Width = _windowTracker.CurrentWindowSize.Width;
 
         Top = _windowTracker.CurrentWindowPosition.Y;
@@ -133,7 +133,10 @@ public partial class OverlayWindow
         _windowTracker.WindowFocusChanged += (_, isFocused) => Dispatcher.Invoke(() =>
             {
                 _logger.LogDebug("Overlay: WindowFocusChanged: {IsFocused}", isFocused);
-                if (Visibility != Visibility.Visible) { return; }
+                if (Visibility != Visibility.Visible)
+                {
+                    return;
+                }
                 Topmost = isFocused;
             }
         );

--- a/src/Arkanis.Overlay.Host.Desktop/Workers/GlobalHotkey.cs
+++ b/src/Arkanis.Overlay.Host.Desktop/Workers/GlobalHotkey.cs
@@ -1,13 +1,13 @@
 namespace Arkanis.Overlay.Host.Desktop.Workers;
 
 using System.Runtime.InteropServices;
-using Windows.Win32.Foundation;
-using Windows.Win32.UI.Input.KeyboardAndMouse;
-using Windows.Win32.UI.WindowsAndMessaging;
 using Domain.Abstractions.Services;
 using Helpers;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Windows.Win32.Foundation;
+using Windows.Win32.UI.Input.KeyboardAndMouse;
+using Windows.Win32.UI.WindowsAndMessaging;
 using PInvoke = Windows.Win32.PInvoke;
 
 /// <summary>

--- a/src/Arkanis.Overlay.Host.Server/Services/WebOverlayControls.cs
+++ b/src/Arkanis.Overlay.Host.Server/Services/WebOverlayControls.cs
@@ -22,26 +22,14 @@ internal sealed class WebOverlayControls : IOverlayControls, IOverlayEventProvid
 
     public ValueTask ShowAsync()
     {
-        _snackbar.Add(
-            "This would open the overlay",
-            configure: options =>
-            {
-                options.ShowCloseIcon = false;
-            }
-        );
+        _snackbar.Add("This would open the overlay", configure: options => options.ShowCloseIcon = false);
         OverlayShown?.Invoke(this, EventArgs.Empty);
         return ValueTask.CompletedTask;
     }
 
     public ValueTask HideAsync()
     {
-        _snackbar.Add(
-            "This would close the overlay",
-            configure: options =>
-            {
-                options.ShowCloseIcon = false;
-            }
-        );
+        _snackbar.Add("This would close the overlay", configure: options => options.ShowCloseIcon = false);
         OverlayHidden?.Invoke(this, EventArgs.Empty);
         return ValueTask.CompletedTask;
     }

--- a/src/Arkanis.Overlay.Infrastructure/Data/DependencyInjection.cs
+++ b/src/Arkanis.Overlay.Infrastructure/Data/DependencyInjection.cs
@@ -8,5 +8,5 @@ public static class DependencyInjection
     public static IServiceCollection AddOverlaySqliteDatabaseServices(this IServiceCollection services)
         => services
             .AddSingleton<IDbContextFactory<OverlayDbContext>, ClientOverlayDbContextFactory>()
-            .AddScoped<OverlayDbContext>(provider => provider.GetRequiredService<IDbContextFactory<OverlayDbContext>>().CreateDbContext());
+            .AddScoped(provider => provider.GetRequiredService<IDbContextFactory<OverlayDbContext>>().CreateDbContext());
 }

--- a/src/Arkanis.Overlay.Infrastructure/Data/Mappers/UexApiDtoMapper.cs
+++ b/src/Arkanis.Overlay.Infrastructure/Data/Mappers/UexApiDtoMapper.cs
@@ -194,7 +194,7 @@ internal partial class UexApiDtoMapper(IGameEntityHydrationService hydrationServ
     private void CacheGameEntityId<T>(double? sourceId, IGameEntity result) where T : class, IGameEntity
         => CachedGameEntities[CreateCacheEntityKey<T>(sourceId)] = result;
 
-    private T? ResolveCachedGameEntity<T>(double? sourceId, bool throwOnCacheMiss = true, [CallerArgumentExpression("sourceId")] string sourceIdExpression = "")
+    private T? ResolveCachedGameEntity<T>(double? sourceId, bool throwOnCacheMiss = true, [CallerArgumentExpression(nameof(sourceId))] string sourceIdExpression = "")
         where T : class, IGameEntity
     {
         var cacheEntityKey = CreateCacheEntityKey<T>(sourceId);
@@ -333,7 +333,7 @@ internal partial class UexApiDtoMapper(IGameEntityHydrationService hydrationServ
         => DateTimeOffset.FromUnixTimeSeconds((long)(timestamp ?? 0));
 
     [DoesNotReturn]
-    private static T ThrowInvalidCacheException<T>(double? sourceId, [CallerArgumentExpression("sourceId")] string sourceIdExpression = "")
+    private static T ThrowInvalidCacheException<T>(double? sourceId, [CallerArgumentExpression(nameof(sourceId))] string sourceIdExpression = "")
         => throw new ObjectMappingMissingLinkedRelatedObjectException(
             $"Could not resolve cached entity instance of {typeof(T)} for: {sourceIdExpression} == {sourceId}"
         );

--- a/src/Arkanis.Overlay.Infrastructure/DependencyInjection.cs
+++ b/src/Arkanis.Overlay.Infrastructure/DependencyInjection.cs
@@ -17,16 +17,8 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddInfrastructure(this IServiceCollection services)
     {
-        services.AddQuartz(options =>
-            {
-                options.UseJobFactory<MicrosoftDependencyInjectionJobFactory>();
-            }
-        );
-        services.AddQuartzHostedService(options =>
-            {
-                options.WaitForJobsToComplete = false;
-            }
-        );
+        services.AddQuartz(options => options.UseJobFactory<MicrosoftDependencyInjectionJobFactory>());
+        services.AddQuartzHostedService(options => options.WaitForJobsToComplete = false);
 
         return services
             .AddSingleton<ServiceDependencyResolver>()


### PR DESCRIPTION
The `dotnet format` command can be used in CI to check that the code conforms to the code style defined.

```
dotnet format --no-restore --verify-no-changes
```

Thought currently some formatting rule behaviour differs between Rider and `dotnet format`.