### PR TITLE
feat(Native): Add Overlay Shutdown Button

### DIFF
--- a/src/Arkanis.Overlay.Components/Shared/Dialogs/ShutdownDialog.razor
+++ b/src/Arkanis.Overlay.Components/Shared/Dialogs/ShutdownDialog.razor
@@ -1,0 +1,45 @@
+@inject IOverlayControls OverlayControls
+
+<MudDialog>
+    <TitleContent>
+        Shutdown Arkanis Overlay?
+    </TitleContent>
+    <DialogContent>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton OnClick="Shutdown" Color="Color.Error" Variant="Variant.Filled">Shutdown</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+
+    [CascadingParameter]
+    private IMudDialogInstance? MudDialog { get; set; }
+
+    private void Cancel()
+        => MudDialog?.Cancel();
+
+    private void Shutdown()
+    {
+        OverlayControls.Shutdown();
+    }
+
+    public static async Task<DialogResult> ShowAsync(IDialogService dialogService)
+    {
+        var dialogOptions = new DialogOptions
+        {
+            FullWidth = true,
+            MaxWidth = MaxWidth.ExtraSmall,
+            CloseOnEscapeKey = true,
+        };
+
+        return await ShowAsync(dialogService, dialogOptions);
+    }
+
+    private static async Task<DialogResult> ShowAsync(IDialogService dialogService, DialogOptions dialogOptions)
+    {
+        var dialogRef = await dialogService.ShowAsync<ShutdownDialog>(null, dialogOptions);
+        return await dialogRef.Result ?? DialogResult.Cancel();
+    }
+}

--- a/src/Arkanis.Overlay.Components/Views/SearchView.razor
+++ b/src/Arkanis.Overlay.Components/Views/SearchView.razor
@@ -131,6 +131,11 @@
                     Class="action"
                     Icon="@MaterialSymbols.Outlined.Settings"
                     OnClick="OpenUserOptionsDialogAsync"/>
+                <MudIconButton
+                    Color="Color.Error"
+                    Class="action"
+                    Icon="@MaterialSymbols.Outlined.PowerSettingsNew"
+                    OnClick="OpenShutdownDialogAsync"/>
             </MudStack>
             <MudSpacer/>
             <MudStack Spacing="1" AlignItems="@AlignItems.End" Justify="@Justify.FlexEnd">
@@ -273,5 +278,8 @@
 
     private async Task OpenAboutDialogAsync()
         => await AboutDialog.ShowAsync(DialogService);
+
+    private async Task OpenShutdownDialogAsync()
+        => await ShutdownDialog.ShowAsync(DialogService);
 
 }

--- a/src/Arkanis.Overlay.Domain/Abstractions/Services/IOverlayControls.cs
+++ b/src/Arkanis.Overlay.Domain/Abstractions/Services/IOverlayControls.cs
@@ -6,4 +6,6 @@ public interface IOverlayControls
     ValueTask HideAsync();
 
     void SetBlurEnabled(bool isEnabled);
+
+    void Shutdown();
 }

--- a/src/Arkanis.Overlay.Host.Desktop/Services/WindowsOverlayControls.cs
+++ b/src/Arkanis.Overlay.Host.Desktop/Services/WindowsOverlayControls.cs
@@ -23,6 +23,9 @@ public class WindowsOverlayControls : IOverlayControls, IOverlayEventProvider, I
     {
     }
 
+    public void Shutdown()
+        => OverlayWindow.Instance?.Exit();
+
     public void OnFocusGained()
         => OverlayFocused?.Invoke(this, EventArgs.Empty);
 

--- a/src/Arkanis.Overlay.Host.Desktop/UI/Windows/OverlayWindow.xaml.cs
+++ b/src/Arkanis.Overlay.Host.Desktop/UI/Windows/OverlayWindow.xaml.cs
@@ -246,4 +246,7 @@ public partial class OverlayWindow
 
     private void OnExitCommand(object sender, RoutedEventArgs e)
         => Application.Current.Shutdown();
+
+    public void Exit()
+        => Dispatcher.Invoke(() => OnExitCommand(this, new RoutedEventArgs()));
 }

--- a/src/Arkanis.Overlay.Host.Desktop/UI/Windows/OverlayWindow.xaml.cs
+++ b/src/Arkanis.Overlay.Host.Desktop/UI/Windows/OverlayWindow.xaml.cs
@@ -22,7 +22,7 @@ using Workers;
 /// <summary>
 ///     Interaction logic for OverlayWindow.xaml
 /// </summary>
-public partial class OverlayWindow
+public sealed partial class OverlayWindow : IDisposable
 {
     private readonly BlurHelper _blurHelper;
     private readonly GlobalHotkey _globalHotkey;
@@ -249,4 +249,18 @@ public partial class OverlayWindow
 
     public void Exit()
         => Dispatcher.Invoke(() => OnExitCommand(this, new RoutedEventArgs()));
+
+    public void Dispose()
+    {
+        _globalHotkey.Dispose();
+        _windowTracker.Dispose();
+        if (BlazorWebView is IDisposable blazorWebViewDisposable)
+        {
+            blazorWebViewDisposable.Dispose();
+        }
+        else if (BlazorWebView != null)
+        {
+            _ = BlazorWebView.DisposeAsync().AsTask();
+        }
+    }
 }

--- a/src/Arkanis.Overlay.Host.Server/Services/WebOverlayControls.cs
+++ b/src/Arkanis.Overlay.Host.Server/Services/WebOverlayControls.cs
@@ -46,6 +46,15 @@ internal sealed class WebOverlayControls : IOverlayControls, IOverlayEventProvid
         return ValueTask.CompletedTask;
     }
 
+    public void Shutdown()
+        => _snackbar.Add(
+            "This would exit the overlay",
+            configure: options =>
+            {
+                options.ShowCloseIcon = false;
+            }
+        );
+
     public void SetBlurEnabled(bool isEnabled)
     {
     }


### PR DESCRIPTION
Adds a button to the Overlay UI that allows to shutdown the Overlay.

![image](https://github.com/user-attachments/assets/15c6cce4-1b2c-494f-b517-30f3a98f3616)

![image](https://github.com/user-attachments/assets/0dca4389-f4a2-4c89-9a34-67e8dc0a8ec1)