### PR TITLE
fix: allow using expired cache when data processing from an available external service endpoint fails

### DIFF
--- a/src/Arkanis.Overlay.Domain/Models/InternalDataState.cs
+++ b/src/Arkanis.Overlay.Domain/Models/InternalDataState.cs
@@ -13,6 +13,8 @@ public sealed record DataCached(ServiceAvailableState SourcedState, DateTimeOffs
     public bool RefreshRequired { get; set; }
 }
 
+public sealed record DataProcessingErrored(Exception Exception) : InternalDataState;
+
 public sealed record DataMissing : InternalDataState
 {
     public static readonly InternalDataState Instance = new DataMissing();

--- a/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexGameEntitySyncRepositoryBase.cs
+++ b/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexGameEntitySyncRepositoryBase.cs
@@ -73,12 +73,12 @@ internal abstract class UexGameEntitySyncRepositoryBase<TSource, TDomain>(
         catch (ExternalApiResponseProcessingException ex)
         {
             Logger.LogError(ex, "Failed processing response from remote API");
-            return await TryGetCachedAsync(internalDataState, cancellationToken);
+            return await TryGetCachedAsync(new DataProcessingErrored(ex), cancellationToken);
         }
         catch (Exception ex)
         {
             Logger.LogCritical(ex, "Failed properly loading {Type} entities", typeof(TDomain).Name);
-            return await TryGetCachedAsync(internalDataState, cancellationToken);
+            return await TryGetCachedAsync(new DataProcessingErrored(ex), cancellationToken);
         }
     }
 


### PR DESCRIPTION
Resolves #288