### PR TITLE
fix: Google Analytics reporting in desktop app

### DIFF
--- a/src/Arkanis.Overlay.Components/Services/ConfigurableGoogleAnalyticsStrategy.cs
+++ b/src/Arkanis.Overlay.Components/Services/ConfigurableGoogleAnalyticsStrategy.cs
@@ -15,6 +15,15 @@ public sealed class ConfigurableGoogleAnalyticsStrategy : IAnalytics
         _strategy.Configure(ApplicationConstants.GoogleAnalyticsTrackingId, !hostEnvironment.IsProduction());
     }
 
+    /// <summary>
+    ///     Configures global tracking configuration properties.
+    /// </summary>
+    /// <remarks>
+    ///     Performs JavaScript interop calls.
+    ///     Must only be called in the <c>AfterRenderAsync</c> component lifecycle hook.
+    /// </remarks>
+    /// <param name="globalConfigData">Configuration data</param>
+    /// <returns>A task that finishes when the tracking interop is configured and initialized</returns>
     public Task ConfigureGlobalConfigData(Dictionary<string, object> globalConfigData)
         => _strategy.ConfigureGlobalConfigData(globalConfigData);
 

--- a/src/Arkanis.Overlay.Components/Services/GoogleGlobalAnalyticsManager.cs
+++ b/src/Arkanis.Overlay.Components/Services/GoogleGlobalAnalyticsManager.cs
@@ -41,6 +41,7 @@ public class GoogleAnalyticsEventReporter(
 
     private void AddCommonEventData(Dictionary<string, object> eventData)
     {
+        //? this is potentially no longer necessary as global event data should be configured on tracking interop level
         foreach (var (propertyName, propertyValue) in analyticsPropertyProvider.PropertyItems)
         {
             eventData[propertyName] = propertyValue;

--- a/src/Arkanis.Overlay.Components/Services/GoogleGlobalAnalyticsManager.cs
+++ b/src/Arkanis.Overlay.Components/Services/GoogleGlobalAnalyticsManager.cs
@@ -28,9 +28,10 @@ public class GoogleAnalyticsEventReporter(
     {
         var eventData = analyticsEvent switch
         {
-            BuiltInFeatureUsageStateChangedEvent @event => CreateSpecificEventData(@event),
+            FeatureUsageStateChangedEvent @event => CreateSpecificEventData(@event),
             DialogOpenedEvent @event => CreateSpecificEventData(@event),
             SearchEvent @event => CreateSpecificEventData(@event),
+            not null => CreateCommonEventData(analyticsEvent),
             _ => [],
         };
 
@@ -46,25 +47,28 @@ public class GoogleAnalyticsEventReporter(
         }
     }
 
-    private static Dictionary<string, object> CreateSpecificEventData(BuiltInFeatureUsageStateChangedEvent @event)
-        => new()
+    private static Dictionary<string, object> CreateSpecificEventData(FeatureUsageStateChangedEvent @event)
+        => new(CreateCommonEventData(@event))
         {
-            [EventCategoryKey] = "Feature",
-            [EventLabelKey] = @event.FeatureName,
             ["value"] = @event.IsEnabled ? 1 : 0,
         };
 
     private static Dictionary<string, object> CreateSpecificEventData(SearchEvent @event)
-        => new()
+        => new(CreateCommonEventData(@event))
         {
             ["search_term"] = @event.Query,
         };
 
     private static Dictionary<string, object> CreateSpecificEventData(DialogOpenedEvent @event)
+        => new(CreateCommonEventData(@event))
+        {
+            ["value"] = @event.DialogId,
+        };
+
+    private static Dictionary<string, object> CreateCommonEventData(AnalyticsEvent @event)
         => new()
         {
-            [EventCategoryKey] = "Dialog",
-            [EventLabelKey] = "Opened",
-            ["value"] = @event.DialogId,
+            [EventCategoryKey] = @event.ModuleName,
+            [EventLabelKey] = @event.EventName,
         };
 }

--- a/src/Arkanis.Overlay.Components/Shared/AnalyticEventSender.razor
+++ b/src/Arkanis.Overlay.Components/Shared/AnalyticEventSender.razor
@@ -1,3 +1,4 @@
+@inject IJSRuntime JsRuntime
 @inject IAnalytics Analytics
 @inject IDialogService DialogService
 @inject IAnalyticsEventReporter AnalyticsEventReporter
@@ -7,12 +8,14 @@
 @inject ILogger<AnalyticEventSender> Logger
 @using Arkanis.Overlay.Domain.Models.Analytics
 @using Microsoft.EntityFrameworkCore.Infrastructure
+@using Microsoft.JSInterop
 @implements IDisposable
 
 <NavigationTracker/>
 
 @code
 {
+    private EventInterop? _eventInterop;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -21,14 +24,22 @@
         if (firstRender)
         {
             await ConfigureAnalyticsAsync(UserRePreferencesProvider.CurrentPreferences);
-            await GlobalAnalyticsReporter.LinkReporterAsync(AnalyticsEventReporter);
+            await LinkAnalyticsReporterAsync();
+
+            _eventInterop = new EventInterop(JsRuntime);
+            var linkAnalyticsHandler = EventInterop.CreateHandler(LinkAnalyticsReporterAsync);
+            await _eventInterop.RegisterWindowEventHandlerAsync("focus", linkAnalyticsHandler);
         }
     }
+
+    private async Task LinkAnalyticsReporterAsync()
+        => await GlobalAnalyticsReporter.LinkReporterAsync(AnalyticsEventReporter);
 
     public void Dispose()
     {
         UserRePreferencesProvider.ApplyPreferences -= OnPreferencesChanged;
         DialogService.DialogInstanceAddedAsync -= OnDialogInstanceAddedAsync;
+        _eventInterop?.Dispose();
     }
 
     protected override void OnInitialized()
@@ -55,8 +66,8 @@
     {
         try
         {
-            await InvokeAsync(StateHasChanged);
             await ConfigureAnalyticsAsync(preferences);
+            await InvokeAsync(StateHasChanged);
         }
         catch (Exception e)
         {
@@ -78,6 +89,7 @@
 
             var globalConfigData = AnalyticsPropertyProvider.PropertyItems.ToDictionary();
             await Analytics.ConfigureGlobalConfigData(globalConfigData);
+            Analytics.ConfigureGlobalEventData(globalConfigData);
         }
     }
 

--- a/src/Arkanis.Overlay.Components/Shared/AnalyticEventSender.razor
+++ b/src/Arkanis.Overlay.Components/Shared/AnalyticEventSender.razor
@@ -1,9 +1,12 @@
 @inject IAnalytics Analytics
+@inject IDialogService DialogService
 @inject IAnalyticsEventReporter AnalyticsEventReporter
 @inject IGlobalAnalyticsReporter GlobalAnalyticsReporter
 @inject IUserPreferencesProvider UserRePreferencesProvider
 @inject SharedAnalyticsPropertyProvider AnalyticsPropertyProvider
 @inject ILogger<AnalyticEventSender> Logger
+@using Arkanis.Overlay.Domain.Models.Analytics
+@using Microsoft.EntityFrameworkCore.Infrastructure
 @implements IDisposable
 
 <NavigationTracker/>
@@ -23,12 +26,29 @@
     }
 
     public void Dispose()
-        => UserRePreferencesProvider.ApplyPreferences -= OnPreferencesChanged;
+    {
+        UserRePreferencesProvider.ApplyPreferences -= OnPreferencesChanged;
+        DialogService.DialogInstanceAddedAsync -= OnDialogInstanceAddedAsync;
+    }
 
     protected override void OnInitialized()
     {
         base.OnInitialized();
         UserRePreferencesProvider.ApplyPreferences += OnPreferencesChanged;
+        DialogService.DialogInstanceAddedAsync += OnDialogInstanceAddedAsync;
+    }
+
+    private Task OnDialogInstanceAddedAsync(IDialogReference arg)
+    {
+        _ = arg.Result.ContinueWith(async _ =>
+            {
+                if (arg.Dialog?.GetType().ShortDisplayName() is { } dialogName)
+                {
+                    await GlobalAnalyticsReporter.TrackEventAsync(new DialogOpenedEvent(dialogName));
+                }
+            }
+        );
+        return Task.CompletedTask;
     }
 
     private async void OnPreferencesChanged(object? _, UserPreferences preferences)

--- a/src/Arkanis.Overlay.Components/Shared/Dialogs/InventoryEntryCreateDialog.razor
+++ b/src/Arkanis.Overlay.Components/Shared/Dialogs/InventoryEntryCreateDialog.razor
@@ -1,7 +1,9 @@
 @using Arkanis.Overlay.Domain.Abstractions.Game
 @using Arkanis.Overlay.Domain.Enums
+@using Arkanis.Overlay.Domain.Models.Analytics
 @using Arkanis.Overlay.Domain.Models.Inventory
 @inject IInventoryManager InventoryManager
+@inject IAnalyticsEventReporter EventReporter
 @inject ILogger<InventoryEntryCreateDialog> Logger
 
 <MudDialog DefaultFocus="@DefaultFocus.Element" ContentClass="py-2">
@@ -76,6 +78,7 @@
 
         var inventoryEntry = InventoryEntry.Create(TargetEntity, TargetQuantity, TargetLocation, TargetList);
         await InventoryManager.AddOrUpdateEntryAsync(inventoryEntry);
+        await EventReporter.TrackEventAsync(InventoryEvents.AddItem());
         MudDialog.Close(DialogResult.Ok(inventoryEntry));
     }
 

--- a/src/Arkanis.Overlay.Components/Shared/Dialogs/InventoryEntryUpdateDialog.razor
+++ b/src/Arkanis.Overlay.Components/Shared/Dialogs/InventoryEntryUpdateDialog.razor
@@ -1,7 +1,9 @@
 @using Arkanis.Overlay.Domain.Abstractions.Game
 @using Arkanis.Overlay.Domain.Enums
+@using Arkanis.Overlay.Domain.Models.Analytics
 @using Arkanis.Overlay.Domain.Models.Inventory
 @inject IInventoryManager InventoryManager
+@inject IAnalyticsEventReporter EventReporter
 @inject ILogger<InventoryEntryUpdateDialog> Logger
 
 <MudDialog DefaultFocus="@DefaultFocus.Element" ContentClass="py-2">
@@ -114,6 +116,16 @@
         if (!CanSubmit)
         {
             return;
+        }
+
+        if (TargetList is not null && SourceModel.List != TargetList)
+        {
+            await EventReporter.TrackEventAsync(InventoryEvents.AssignList());
+        }
+
+        if (TargetLocation is not null && SourceModel is IGameLocatedAt locatedAt && locatedAt.Location.Id != TargetLocation.Id)
+        {
+            await EventReporter.TrackEventAsync(InventoryEvents.AssignLocation());
         }
 
         if (IsEditMode || TargetQuantity == SourceModel.Quantity)

--- a/src/Arkanis.Overlay.Components/Shared/Dialogs/InventoryListDialog.razor
+++ b/src/Arkanis.Overlay.Components/Shared/Dialogs/InventoryListDialog.razor
@@ -1,5 +1,7 @@
+@using Arkanis.Overlay.Domain.Models.Analytics
 @using Arkanis.Overlay.Domain.Models.Inventory
 @inject IInventoryManager InventoryManager
+@inject IAnalyticsEventReporter EventReporter
 @inject ILogger<InventoryListDialog> Logger
 
 <MudDialog DefaultFocus="@DefaultFocus.Element" ContentClass="py-2">
@@ -44,9 +46,17 @@
     [Parameter]
     public InventoryEntryList Model { get; set; } = CreateDefaultModel();
 
+    [Parameter]
+    public bool IsEdit { get; set; }
+
     private async Task SubmitAsync()
     {
         await InventoryManager.AddOrUpdateListAsync(Model);
+        if (!IsEdit)
+        {
+            await EventReporter.TrackEventAsync(InventoryEvents.AddList());
+        }
+
         MudDialog.Close(DialogResult.Ok(Model));
     }
 
@@ -58,6 +68,7 @@
         var dialogParameters = new DialogParameters<InventoryListDialog>
         {
             [nameof(Model)] = model ?? CreateDefaultModel(),
+            [nameof(IsEdit)] = model is not null,
         };
         var dialogOptions = new DialogOptions
         {

--- a/src/Arkanis.Overlay.Components/Shared/Dialogs/UserPreferencesDialog.razor
+++ b/src/Arkanis.Overlay.Components/Shared/Dialogs/UserPreferencesDialog.razor
@@ -227,7 +227,7 @@
 
     private static async Task<DialogResult> ShowAsync(IDialogService dialogService, DialogOptions dialogOptions)
     {
-        var dialogRef = await dialogService.ShowAsync<UserPreferencesEditDialog>(null, dialogOptions);
+        var dialogRef = await dialogService.ShowAsync<UserPreferencesDialog>(null, dialogOptions);
         return await dialogRef.Result ?? DialogResult.Cancel();
     }
 

--- a/src/Arkanis.Overlay.Components/Shared/GameEntitySearchControls.razor
+++ b/src/Arkanis.Overlay.Components/Shared/GameEntitySearchControls.razor
@@ -208,5 +208,5 @@
     }
 
     private async Task OnAddAsync()
-        => await InventoryEntryUpdateDialog.ShowEditAsync(DialogService, Model, CurrentLocation);
+        => await InventoryEntryCreateDialog.ShowAsync(DialogService, Model, CurrentLocation);
 }

--- a/src/Arkanis.Overlay.Components/Shared/OverlayControls.razor
+++ b/src/Arkanis.Overlay.Components/Shared/OverlayControls.razor
@@ -91,7 +91,7 @@
 {
 
     private async Task OpenUserOptionsDialogAsync()
-        => await UserPreferencesEditDialog.ShowAsync(DialogService);
+        => await UserPreferencesDialog.ShowAsync(DialogService);
 
     private async Task OpenAboutDialogAsync()
         => await AboutDialog.ShowAsync(DialogService);

--- a/src/Arkanis.Overlay.Components/Views/InventoryView.razor
+++ b/src/Arkanis.Overlay.Components/Views/InventoryView.razor
@@ -2,9 +2,11 @@
 @using Arkanis.Overlay.Components.Shared.Dialogs
 @using Arkanis.Overlay.Domain.Abstractions
 @using Arkanis.Overlay.Domain.Abstractions.Game
+@using Arkanis.Overlay.Domain.Models.Analytics
 @using Arkanis.Overlay.Domain.Models.Inventory
 @using Arkanis.Overlay.Domain.Models.Keyboard
 @inject IDialogService DialogService
+@inject IAnalyticsEventReporter EventReporter
 @inject IInventoryManager InventoryManager
 
 <PageTitle>@ApplicationConstants.ApplicationName — Inventory</PageTitle>
@@ -599,7 +601,11 @@
 
         var configuration = new BulkOperationDialog<InventoryEntryBase>.Configuration
         {
-            PerformOperation = async entry => await InventoryManager.AddOrUpdateEntryAsync(entry.SetLocation(location)),
+            PerformOperation = async entry =>
+            {
+                await InventoryManager.AddOrUpdateEntryAsync(entry.SetLocation(location));
+                await EventReporter.TrackEventAsync(InventoryEvents.AssignLocation());
+            },
             Description = @<div>
                 <MudText Typo="@Typo.inherit">Please confirm inventory transfer to:</MudText>
                 <div class="pl-4">
@@ -635,6 +641,7 @@
             {
                 entry.List = list;
                 await InventoryManager.AddOrUpdateEntryAsync(entry);
+                await EventReporter.TrackEventAsync(InventoryEvents.AssignList());
             },
             Description = @<div>
                 <MudText Typo="@Typo.inherit">Please confirm list (re-)assignment to:</MudText>
@@ -664,7 +671,11 @@
     {
         var configuration = new BulkOperationDialog<InventoryEntryBase>.Configuration
         {
-            PerformOperation = async entry => await InventoryManager.DeleteEntryAsync(entry.Id),
+            PerformOperation = async entry =>
+            {
+                await InventoryManager.DeleteEntryAsync(entry.Id);
+                await EventReporter.TrackEventAsync(InventoryEvents.RemoveItem());
+            },
             Description = @<div>
                 <MudText Typo="@Typo.inherit">
                     Please confirm <u>permanent removal</u> of the following inventory entries:
@@ -696,6 +707,7 @@
         if (await DialogService.ShowMessageBox(options) == true)
         {
             await InventoryManager.DeleteListAsync(contextItem.Id);
+            await EventReporter.TrackEventAsync(InventoryEvents.RemoveList());
             await RefreshDataAsync();
             await InvokeAsync(StateHasChanged);
         }
@@ -716,6 +728,7 @@
         if (await DialogService.ShowMessageBox(options) == true)
         {
             await InventoryManager.DeleteEntryAsync(contextItem.Id);
+            await EventReporter.TrackEventAsync(InventoryEvents.RemoveItem());
             await RefreshDataAsync();
             await InvokeAsync(StateHasChanged);
         }

--- a/src/Arkanis.Overlay.Domain/Abstractions/Services/IAnalyticsEventReporter.cs
+++ b/src/Arkanis.Overlay.Domain/Abstractions/Services/IAnalyticsEventReporter.cs
@@ -2,6 +2,9 @@ namespace Arkanis.Overlay.Domain.Abstractions.Services;
 
 using Models.Analytics;
 
+/// <summary>
+///     An analytics reporter which can not be generally used in global singleton context.
+/// </summary>
 public interface IAnalyticsEventReporter
 {
     Task TrackEventAsync(AnalyticsEvent analyticsEvent);

--- a/src/Arkanis.Overlay.Domain/Models/Analytics/AnalyticsEvent.cs
+++ b/src/Arkanis.Overlay.Domain/Models/Analytics/AnalyticsEvent.cs
@@ -27,6 +27,43 @@ public sealed record DialogOpenedEvent(string DialogId) : BuiltInAnalyticsEvent(
 
 #endregion
 
+#region Inventory events
+
+public static class InventoryEvents
+{
+    public static InventoryAddItem AddItem()
+        => new();
+
+    public static InventoryRemoveItem RemoveItem()
+        => new();
+
+    public static InventoryTransferItem AssignLocation()
+        => new();
+
+    public static InventoryAddList AddList()
+        => new();
+
+    public static InventoryRemoveList RemoveList()
+        => new();
+
+    public static InventoryAssignList AssignList()
+        => new();
+}
+
+public sealed record InventoryAddList() : BuiltInAnalyticsEvent("inventory_list_add");
+
+public sealed record InventoryRemoveList() : BuiltInAnalyticsEvent("inventory_list_remove");
+
+public sealed record InventoryAssignList() : BuiltInAnalyticsEvent("inventory_list_assign");
+
+public sealed record InventoryAddItem() : BuiltInAnalyticsEvent("inventory_item_add");
+
+public sealed record InventoryRemoveItem() : BuiltInAnalyticsEvent("inventory_item_remove");
+
+public sealed record InventoryTransferItem() : BuiltInAnalyticsEvent("inventory_item_transfer");
+
+#endregion
+
 #region Regular events
 
 public sealed record SearchCalculationEvent() : BuiltInAnalyticsEvent("search_calculate");

--- a/src/Arkanis.Overlay.Domain/Models/Analytics/AnalyticsEvent.cs
+++ b/src/Arkanis.Overlay.Domain/Models/Analytics/AnalyticsEvent.cs
@@ -2,19 +2,32 @@ namespace Arkanis.Overlay.Domain.Models.Analytics;
 
 public abstract record AnalyticsEvent(string EventName, string ModuleName);
 
-public record BuiltInAnalyticsEvent(string EventName) : AnalyticsEvent(EventName, "Arkanis.Overlay");
+public record BuiltInAnalyticsEvent(string EventName) : AnalyticsEvent(EventName, "user_behaviour");
 
-public abstract record BuiltInFeatureUsageStateChangedEvent(string FeatureName, bool IsEnabled) : BuiltInAnalyticsEvent("feature_usage_state_changed");
+#region Events with custom values (must also be explicitly registered in global analytics manager to work properly)
 
-public sealed record TerminateWithGameFeatureStateChangedEvent(bool IsEnabled) : BuiltInFeatureUsageStateChangedEvent("overlay__app__terminate", IsEnabled);
+public record FeatureUsageStateChangedEvent(string EventName, bool IsEnabled) : AnalyticsEvent(EventName, "feature_usage_state_changed")
+{
+    public static FeatureUsageStateChangedEvent TerminateWithGame(bool enabled = true)
+        => new("overlay__app__terminate", enabled);
 
-public sealed record AutoStartFeatureStateChangedEvent(bool IsEnabled) : BuiltInFeatureUsageStateChangedEvent("overlay__app__autostart", IsEnabled);
+    public static FeatureUsageStateChangedEvent AutoStart(bool enabled = true)
+        => new("overlay__app__autostart", enabled);
 
-public sealed record AnalyticsFeatureStateChangedEvent(bool IsEnabled) : BuiltInFeatureUsageStateChangedEvent("overlay__app__analytics", IsEnabled);
+    public static FeatureUsageStateChangedEvent Analytics(bool enabled = true)
+        => new("overlay__app__analytics", enabled);
 
-public sealed record BlurFeatureStateChangedEvent(bool IsEnabled) : BuiltInFeatureUsageStateChangedEvent("overlay__blur", IsEnabled);
+    public static FeatureUsageStateChangedEvent BlurBackground(bool enabled = true)
+        => new("overlay__blur", enabled);
+}
 
 public sealed record SearchEvent(string Query) : BuiltInAnalyticsEvent("search");
+
+public sealed record DialogOpenedEvent(string DialogId) : BuiltInAnalyticsEvent("dialog_opened");
+
+#endregion
+
+#region Regular events
 
 public sealed record SearchCalculationEvent() : BuiltInAnalyticsEvent("search_calculate");
 
@@ -22,4 +35,4 @@ public sealed record OverlayShownEvent() : BuiltInAnalyticsEvent("overlay_shown"
 
 public sealed record OverlayHiddenEvent() : BuiltInAnalyticsEvent("overlay_hidden");
 
-public sealed record DialogOpenedEvent(string DialogId) : BuiltInAnalyticsEvent(nameof(DialogOpenedEvent));
+#endregion

--- a/src/Arkanis.Overlay.Host.Desktop/UI/Pages/PreferencesDialogPage.razor
+++ b/src/Arkanis.Overlay.Host.Desktop/UI/Pages/PreferencesDialogPage.razor
@@ -10,7 +10,7 @@
 {
 
     protected override Task OnInitializedAsync()
-        => UserPreferencesEditDialog.ShowFullscreenAsync(DialogService)
+        => UserPreferencesDialog.ShowFullscreenAsync(DialogService)
             .ContinueWith(_ => WindowControls.CloseAsync());
 
 }

--- a/src/Arkanis.Overlay.Host.Desktop/wwwroot/index.html
+++ b/src/Arkanis.Overlay.Host.Desktop/wwwroot/index.html
@@ -24,6 +24,7 @@
 </div>
 <script src="_framework/blazor.webview.js"></script>
 <script src="_content/Arkanis.Overlay.Components/js/EventInterop.js"></script>
+<script src="_content/Blazor-Analytics/blazor-analytics.js"></script>
 <script src="_content/MudBlazor/MudBlazor.min.js"></script>
 </body>
 

--- a/src/Arkanis.Overlay.Infrastructure/Services/UserPreferencesJsonFileManager.cs
+++ b/src/Arkanis.Overlay.Infrastructure/Services/UserPreferencesJsonFileManager.cs
@@ -89,10 +89,10 @@ public class UserPreferencesJsonFileManager(IGlobalAnalyticsReporter analyticsRe
 
     private async Task TrackFeatureChangesAsync(UserPreferences @new)
     {
-        await TrackIfChangedAsync(x => x.BlurBackground, newValue => new BlurFeatureStateChangedEvent(newValue));
-        await TrackIfChangedAsync(x => x.TerminateOnGameExit, newValue => new TerminateWithGameFeatureStateChangedEvent(newValue));
-        await TrackIfChangedAsync(x => x.AutoStartWithBoot, newValue => new AutoStartFeatureStateChangedEvent(newValue));
-        await TrackIfChangedAsync(x => x.DisableAnalytics, newValue => new AnalyticsFeatureStateChangedEvent(!newValue));
+        await TrackIfChangedAsync(x => x.BlurBackground, FeatureUsageStateChangedEvent.BlurBackground);
+        await TrackIfChangedAsync(x => x.TerminateOnGameExit, FeatureUsageStateChangedEvent.TerminateWithGame);
+        await TrackIfChangedAsync(x => x.AutoStartWithBoot, FeatureUsageStateChangedEvent.AutoStart);
+        await TrackIfChangedAsync(x => x.DisableAnalytics, newValue => FeatureUsageStateChangedEvent.Analytics(!newValue));
 
         return;
 


### PR DESCRIPTION
- the desktop app version was missing JavaScript interop logic
- dialog tracking events were not properly set-up
- event category and label was not consistent
- global event data was not configured properly
- refactoring of event handling in various places