### PR TITLE
fix: log output

### DIFF
--- a/.run/Arkanis.Overlay.Host.Desktop.run.xml
+++ b/.run/Arkanis.Overlay.Host.Desktop.run.xml
@@ -1,13 +1,13 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Arkanis.Overlay.Host.Desktop" type="DotNetProject" factoryName=".NET Project">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/artifacts/bin/Arkanis.Overlay.Host.Desktop/debug/Arkanis.Overlay.Host.Desktop.exe" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/artifacts/bin/Arkanis.Overlay.Host.Desktop/debug/ArkanisOverlay.exe" />
     <option name="PROGRAM_PARAMETERS" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/src/Arkanis.Overlay.Host.Desktop" />
     <option name="PASS_PARENT_ENVS" value="1" />
     <envs>
       <env name="DOTNET_ENVIRONMENT" value="Development" />
     </envs>
-    <option name="USE_EXTERNAL_CONSOLE" value="0" />
+    <option name="USE_EXTERNAL_CONSOLE" value="1" />
     <option name="ENV_FILE_PATHS" value="" />
     <option name="REDIRECT_INPUT_PATH" value="" />
     <option name="PTY_MODE" value="Auto" />

--- a/.run/Arkanis.Overlay.Host.Server.run.xml
+++ b/.run/Arkanis.Overlay.Host.Server.run.xml
@@ -3,7 +3,7 @@
     <option name="LAUNCH_PROFILE_PROJECT_FILE_PATH" value="$PROJECT_DIR$/src/Arkanis.Overlay.Host.Server/Arkanis.Overlay.Host.Server.csproj" />
     <option name="LAUNCH_PROFILE_TFM" value="net8.0" />
     <option name="LAUNCH_PROFILE_NAME" value="http" />
-    <option name="USE_EXTERNAL_CONSOLE" value="0" />
+    <option name="USE_EXTERNAL_CONSOLE" value="1" />
     <option name="USE_MONO" value="0" />
     <option name="RUNTIME_ARGUMENTS" value="" />
     <option name="GENERATE_APPLICATIONHOST_CONFIG" value="1" />
@@ -22,7 +22,7 @@
     <envs>
       <env name="DOTNET_ENVIRONMENT" value="Development" />
     </envs>
-    <option name="USE_EXTERNAL_CONSOLE" value="0" />
+    <option name="USE_EXTERNAL_CONSOLE" value="1" />
     <option name="ENV_FILE_PATHS" value="" />
     <option name="REDIRECT_INPUT_PATH" value="" />
     <option name="PTY_MODE" value="Auto" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,73 +1,74 @@
 <Project>
-    <PropertyGroup>
-        <!-- https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management -->
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-        <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageVersion Include="Blazor-Analytics" Version="3.12.0"/>
-        <PackageVersion Include="coverlet.collector" Version="6.0.4"/>
-        <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices" Version="1.0.14"/>
-        <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Plugins" Version="1.0.14"/>
-        <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf" Version="1.0.14"/>
-        <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0"/>
-        <PackageVersion Include="FluentValidation" Version="12.0.0"/>
-        <PackageVersion Include="FuzzySharp" Version="2.0.2"/>
-        <PackageVersion Include="Humanizer" Version="2.14.1"/>
-        <PackageVersion Include="MathEvaluator" Version="2.3.1"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.16"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.16"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Wpf" Version="8.0.100"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Http.Extensions" Version="2.3.0"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.3.0"/>
-        <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.16"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.16"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.16"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0"/>
-        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0"/>
-        <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0"/>
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0"/>
-        <PackageVersion Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3"/>
-        <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0"/>
-        <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.183"/>
-        <PackageVersion Include="MoreAsyncLINQ" Version="0.8.0"/>
-        <PackageVersion Include="morelinq" Version="4.4.0"/>
-        <PackageVersion Include="MudBlazor.FontIcons.MaterialIcons" Version="1.3.0"/>
-        <PackageVersion Include="MudBlazor.FontIcons.MaterialSymbols" Version="1.3.0"/>
-        <PackageVersion Include="MudBlazor" Version="8.6.0"/>
-        <PackageVersion Include="NuGet.Versioning" Version="6.14.0"/>
-        <PackageVersion Include="Octokit" Version="14.0.0"/>
-        <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="3.14.0"/>
-        <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.14.0"/>
-        <PackageVersion Include="Quartz.Jobs" Version="3.14.0"/>
-        <PackageVersion Include="Quartz" Version="3.14.0"/>
-        <PackageVersion Include="Riok.Mapperly" Version="4.2.1"/>
-        <PackageVersion Include="Scrutor" Version="6.0.1"/>
-        <PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0"/>
-        <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.4"/>
-        <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0"/>
-        <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0"/>
-        <PackageVersion Include="Serilog" Version="4.3.0"/>
-        <PackageVersion Include="Shouldly" Version="4.3.0"/>
-        <PackageVersion Include="SingleInstanceCore" Version="2.2.2"/>
-        <PackageVersion Include="TrayIcon" Version="1.1.1.1"/>
-        <PackageVersion Include="Velopack" Version="0.0.1251"/>
-        <PackageVersion Include="xunit" Version="2.9.3"/>
-        <PackageVersion Include="Xunit.Microsoft.DependencyInjection" Version="8.2.2"/>
-        <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0"/>
-    </ItemGroup>
+  <PropertyGroup>
+    <!-- https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management -->
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Blazor-Analytics" Version="3.12.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices" Version="1.0.14" />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Plugins" Version="1.0.14" />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf" Version="1.0.14" />
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
+    <PackageVersion Include="FluentValidation" Version="12.0.0" />
+    <PackageVersion Include="FuzzySharp" Version="2.0.2" />
+    <PackageVersion Include="Humanizer" Version="2.14.1" />
+    <PackageVersion Include="MathEvaluator" Version="2.3.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.16" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.16" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Wpf" Version="8.0.100" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http.Extensions" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.16" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.16" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.16" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageVersion Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
+    <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.183" />
+    <PackageVersion Include="MoreAsyncLINQ" Version="0.8.0" />
+    <PackageVersion Include="morelinq" Version="4.4.0" />
+    <PackageVersion Include="MudBlazor.FontIcons.MaterialIcons" Version="1.3.0" />
+    <PackageVersion Include="MudBlazor.FontIcons.MaterialSymbols" Version="1.3.0" />
+    <PackageVersion Include="MudBlazor" Version="8.6.0" />
+    <PackageVersion Include="NuGet.Versioning" Version="6.14.0" />
+    <PackageVersion Include="Octokit" Version="14.0.0" />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="3.14.0" />
+    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.14.0" />
+    <PackageVersion Include="Quartz.Jobs" Version="3.14.0" />
+    <PackageVersion Include="Quartz" Version="3.14.0" />
+    <PackageVersion Include="Riok.Mapperly" Version="4.2.1" />
+    <PackageVersion Include="Scrutor" Version="6.0.1" />
+    <PackageVersion Include="Serilog.Expressions" Version="5.1.0-dev-02301" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.4" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="SingleInstanceCore" Version="2.2.2" />
+    <PackageVersion Include="TrayIcon" Version="1.1.1.1" />
+    <PackageVersion Include="Velopack" Version="0.0.1251" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="Xunit.Microsoft.DependencyInjection" Version="8.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
+  </ItemGroup>
 </Project>

--- a/src/Arkanis.Overlay.Host.Desktop/Arkanis.Overlay.Host.Desktop.csproj
+++ b/src/Arkanis.Overlay.Host.Desktop/Arkanis.Overlay.Host.Desktop.csproj
@@ -54,6 +54,7 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Serilog"/>
+        <PackageReference Include="Serilog.Expressions" />
         <PackageReference Include="Serilog.Extensions.Hosting"/>
         <PackageReference Include="Serilog.Settings.Configuration"/>
         <PackageReference Include="Serilog.Sinks.Console"/>

--- a/src/Arkanis.Overlay.Host.Desktop/NativeMethods.txt
+++ b/src/Arkanis.Overlay.Host.Desktop/NativeMethods.txt
@@ -91,3 +91,7 @@ GetModuleFileNameEx
 
 PostThreadMessage
 GetCurrentThreadId
+
+// Console Allocation
+AttachConsole
+ATTACH_PARENT_PROCESS

--- a/src/Arkanis.Overlay.Host.Desktop/appsettings.Development.json
+++ b/src/Arkanis.Overlay.Host.Desktop/appsettings.Development.json
@@ -2,10 +2,12 @@
     "ConnectionStrings": {
         "OverlayDatabase": "Data Source=./Overlay.db;Cache=Shared"
     },
-    "Logging": {
-        "LogLevel": {
+    "Serilog": {
+        "MinimumLevel": {
             "Default": "Debug",
-            "Microsoft.AspNetCore": "Warning"
+            "Override": {
+                "Microsoft.AspNetCore": "Warning"
+            }
         }
     }
 }

--- a/src/Arkanis.Overlay.Host.Desktop/packages.lock.json
+++ b/src/Arkanis.Overlay.Host.Desktop/packages.lock.json
@@ -232,6 +232,15 @@
         "resolved": "4.3.0",
         "contentHash": "+cDryFR0GRhsGOnZSKwaDzRRl4MupvJ42FhCE4zhQRVanX0Jpg6WuCBk59OVhVDPmab1bB+nRykAnykYELA9qQ=="
       },
+      "Serilog.Expressions": {
+        "type": "Direct",
+        "requested": "[5.1.0-dev-02301, )",
+        "resolved": "5.1.0-dev-02301",
+        "contentHash": "hW7OKCr8m/5h84oTFeXSnnfqFozn05h9BfU+1kMLLFvSmJPjRhaxqVqR/zs2+g9kD8s0d9CSRCwhtZAshbyvUg==",
+        "dependencies": {
+          "Serilog": "4.2.0"
+        }
+      },
       "Serilog.Extensions.Hosting": {
         "type": "Direct",
         "requested": "[8.0.0, )",

--- a/src/Arkanis.Overlay.Host.Server/Arkanis.Overlay.Host.Server.csproj
+++ b/src/Arkanis.Overlay.Host.Server/Arkanis.Overlay.Host.Server.csproj
@@ -27,6 +27,7 @@
     <ItemGroup>
         <PackageReference Include="Octokit"/>
         <PackageReference Include="Serilog"/>
+        <PackageReference Include="Serilog.Expressions" />
         <PackageReference Include="Serilog.Extensions.Hosting"/>
         <PackageReference Include="Serilog.Settings.Configuration"/>
         <PackageReference Include="Serilog.Sinks.Console"/>

--- a/src/Arkanis.Overlay.Host.Server/DependencyInjection.cs
+++ b/src/Arkanis.Overlay.Host.Server/DependencyInjection.cs
@@ -1,5 +1,6 @@
 namespace Arkanis.Overlay.Host.Server;
 
+using System.Globalization;
 using Common.Abstractions;
 using Common.Enums;
 using Common.Services;
@@ -11,6 +12,8 @@ using MudBlazor.Services;
 using Overlay.Components.Helpers;
 using Overlay.Components.Services;
 using Serilog;
+using Serilog.Templates;
+using Serilog.Templates.Themes;
 using Services;
 
 public static class DependencyInjection
@@ -18,6 +21,14 @@ public static class DependencyInjection
     public static IServiceCollection AddAllServerHostServices(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddSerilog(loggerConfig => loggerConfig
+            .WriteTo.Console(
+                new ExpressionTemplate(
+                    "[{@t:HH:mm:ss} {@l:u3}] [{Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1)}] {@m}\n{@x}",
+                    CultureInfo.InvariantCulture,
+                    applyThemeWhenOutputIsRedirected: true,
+                    theme: TemplateTheme.Literate
+                )
+            )
             .Enrich.FromLogContext()
             .ReadFrom.Configuration(configuration)
         );

--- a/src/Arkanis.Overlay.Host.Server/appsettings.json
+++ b/src/Arkanis.Overlay.Host.Server/appsettings.json
@@ -1,14 +1,5 @@
 {
     "Serilog": {
-        "Using":  [ "Serilog.Sinks.Console" ],
-        "WriteTo": [
-            {
-                "Name": "Console",
-                "Args": {
-                    "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] ({SourceContext}) {Message:lj}{NewLine}{Exception}"
-                }
-            }
-        ],
         "MinimumLevel": {
             "Default": "Debug",
             "Override": {

--- a/src/Arkanis.Overlay.Host.Server/packages.lock.json
+++ b/src/Arkanis.Overlay.Host.Server/packages.lock.json
@@ -14,6 +14,15 @@
         "resolved": "4.3.0",
         "contentHash": "+cDryFR0GRhsGOnZSKwaDzRRl4MupvJ42FhCE4zhQRVanX0Jpg6WuCBk59OVhVDPmab1bB+nRykAnykYELA9qQ=="
       },
+      "Serilog.Expressions": {
+        "type": "Direct",
+        "requested": "[5.1.0-dev-02301, )",
+        "resolved": "5.1.0-dev-02301",
+        "contentHash": "hW7OKCr8m/5h84oTFeXSnnfqFozn05h9BfU+1kMLLFvSmJPjRhaxqVqR/zs2+g9kD8s0d9CSRCwhtZAshbyvUg==",
+        "dependencies": {
+          "Serilog": "4.2.0"
+        }
+      },
       "Serilog.Extensions.Hosting": {
         "type": "Direct",
         "requested": "[8.0.0, )",

--- a/tests/Arkanis.Overlay.Host.Desktop.UnitTests/packages.lock.json
+++ b/tests/Arkanis.Overlay.Host.Desktop.UnitTests/packages.lock.json
@@ -1669,11 +1669,11 @@
       },
       "Serilog.Expressions": {
         "type": "CentralTransitive",
-        "requested": "[5.0.0, )",
-        "resolved": "5.0.0",
-        "contentHash": "QhZjXtUcA2QfQRA60m+DfyIfidKsQV7HBstbYEDqzJKMbJH/KnKthkkjciRuYrmFE+scWv1JibC5LlXrdtOUmw==",
+        "requested": "[5.1.0-dev-02301, )",
+        "resolved": "5.1.0-dev-02301",
+        "contentHash": "hW7OKCr8m/5h84oTFeXSnnfqFozn05h9BfU+1kMLLFvSmJPjRhaxqVqR/zs2+g9kD8s0d9CSRCwhtZAshbyvUg==",
         "dependencies": {
-          "Serilog": "4.0.0"
+          "Serilog": "4.2.0"
         }
       },
       "Serilog.Extensions.Hosting": {

--- a/tests/Arkanis.Overlay.Host.Desktop.UnitTests/packages.lock.json
+++ b/tests/Arkanis.Overlay.Host.Desktop.UnitTests/packages.lock.json
@@ -1147,6 +1147,7 @@
           "Microsoft.Toolkit.Uwp.Notifications": "[7.1.3, )",
           "Microsoft.Win32.Registry": "[5.0.0, )",
           "Serilog": "[4.3.0, )",
+          "Serilog.Expressions": "[5.1.0-dev-02301, )",
           "Serilog.Extensions.Hosting": "[8.0.0, )",
           "Serilog.Settings.Configuration": "[8.0.4, )",
           "Serilog.Sinks.Console": "[6.0.0, )",
@@ -1665,6 +1666,15 @@
         "requested": "[4.3.0, )",
         "resolved": "4.3.0",
         "contentHash": "+cDryFR0GRhsGOnZSKwaDzRRl4MupvJ42FhCE4zhQRVanX0Jpg6WuCBk59OVhVDPmab1bB+nRykAnykYELA9qQ=="
+      },
+      "Serilog.Expressions": {
+        "type": "CentralTransitive",
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "QhZjXtUcA2QfQRA60m+DfyIfidKsQV7HBstbYEDqzJKMbJH/KnKthkkjciRuYrmFE+scWv1JibC5LlXrdtOUmw==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
       },
       "Serilog.Extensions.Hosting": {
         "type": "CentralTransitive",

--- a/tests/Arkanis.Overlay.Host.Server.UnitTests/packages.lock.json
+++ b/tests/Arkanis.Overlay.Host.Server.UnitTests/packages.lock.json
@@ -1320,11 +1320,11 @@
       },
       "Serilog.Expressions": {
         "type": "CentralTransitive",
-        "requested": "[5.0.0, )",
-        "resolved": "5.0.0",
-        "contentHash": "QhZjXtUcA2QfQRA60m+DfyIfidKsQV7HBstbYEDqzJKMbJH/KnKthkkjciRuYrmFE+scWv1JibC5LlXrdtOUmw==",
+        "requested": "[5.1.0-dev-02301, )",
+        "resolved": "5.1.0-dev-02301",
+        "contentHash": "hW7OKCr8m/5h84oTFeXSnnfqFozn05h9BfU+1kMLLFvSmJPjRhaxqVqR/zs2+g9kD8s0d9CSRCwhtZAshbyvUg==",
         "dependencies": {
-          "Serilog": "4.0.0"
+          "Serilog": "4.2.0"
         }
       },
       "Serilog.Extensions.Hosting": {

--- a/tests/Arkanis.Overlay.Host.Server.UnitTests/packages.lock.json
+++ b/tests/Arkanis.Overlay.Host.Server.UnitTests/packages.lock.json
@@ -932,6 +932,7 @@
           "Arkanis.Overlay.Infrastructure": "[1.0.0, )",
           "Octokit": "[14.0.0, )",
           "Serilog": "[4.3.0, )",
+          "Serilog.Expressions": "[5.1.0-dev-02301, )",
           "Serilog.Extensions.Hosting": "[8.0.0, )",
           "Serilog.Settings.Configuration": "[8.0.4, )",
           "Serilog.Sinks.Console": "[6.0.0, )"
@@ -1316,6 +1317,15 @@
         "requested": "[4.3.0, )",
         "resolved": "4.3.0",
         "contentHash": "+cDryFR0GRhsGOnZSKwaDzRRl4MupvJ42FhCE4zhQRVanX0Jpg6WuCBk59OVhVDPmab1bB+nRykAnykYELA9qQ=="
+      },
+      "Serilog.Expressions": {
+        "type": "CentralTransitive",
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "QhZjXtUcA2QfQRA60m+DfyIfidKsQV7HBstbYEDqzJKMbJH/KnKthkkjciRuYrmFE+scWv1JibC5LlXrdtOUmw==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
       },
       "Serilog.Extensions.Hosting": {
         "type": "CentralTransitive",


### PR DESCRIPTION
- fix WPF app not attaching to terminal
- fix desktop host not colorizing log output in Rider debug terminal
- fix missing console log output for desktop host
- fix & unify log format

Makes it possible to launch the app through the terminal and see (human-readable & colorized) log output.

<img width="993" height="561" alt="image" src="https://github.com/user-attachments/assets/cf5d5c3e-9421-415f-982e-63fee3be7861" />
