### PR TITLE
fix: indicate whether terminal of commodity price is within searched location

### DIFF
--- a/src/Arkanis.Overlay.Components/Shared/GameEntityNameCodePart.razor
+++ b/src/Arkanis.Overlay.Components/Shared/GameEntityNameCodePart.razor
@@ -6,9 +6,21 @@
     {
         <span>@PrefixContent</span>
     }
-    <MudTooltip Text="@TooltipContent" Placement="@Placement.Top">
-        <span>@Model.Code</span>
-    </MudTooltip>
+    <Tooltip>
+        <TooltipContent>
+            @if (TooltipContent is not null)
+            {
+                @TooltipContent
+            }
+            else
+            {
+                @DefaultTooltipText
+            }
+        </TooltipContent>
+        <ChildContent>
+            <span>@Model.Code</span>
+        </ChildContent>
+    </Tooltip>
 </MudText>
 
 @code
@@ -38,7 +50,10 @@
     [Parameter]
     public RenderFragment? PrefixContent { get; set; }
 
-    public string TooltipContent
+    [Parameter]
+    public RenderFragment? TooltipContent { get; set; }
+
+    public string DefaultTooltipText
         => Model is GameEntityName.Name name
             ? name.FullName
             : Model.Code;

--- a/src/Arkanis.Overlay.Components/Shared/GameLocationLabel.razor
+++ b/src/Arkanis.Overlay.Components/Shared/GameLocationLabel.razor
@@ -12,6 +12,18 @@
                 </span>
             }
         </PrefixContent>
+        <TooltipContent>
+            <GameLocationNamePart Model="@Model.Name.Location"
+                                  Style="height: 24px; margin-top: -8px">
+                <SuffixContent>
+                    @GameLocationNamePart.Separator
+                    <GameEntityNamePart
+                        Model="@Model.Name.MainContent"
+                        Typo="@Typo.inherit"
+                        Embedded/>
+                </SuffixContent>
+            </GameLocationNamePart>
+        </TooltipContent>
     </GameEntityNameCodePart>
 }
 else

--- a/src/Arkanis.Overlay.Components/Shared/GameLocationNamePart.razor
+++ b/src/Arkanis.Overlay.Components/Shared/GameLocationNamePart.razor
@@ -1,7 +1,8 @@
 <MudStack Spacing="2"
           AlignItems="@AlignItems.Baseline"
           Class="no-wrap"
-          Reverse="Reverse"
+          Style="@Style"
+          Reverse="@Reverse"
           Row>
     @PrefixContent
     @foreach (var (index, subLocation) in Model.Location.CreatePathToRoot().Index())
@@ -27,6 +28,9 @@
 
     [Parameter]
     public required GameEntityName.LocationReference Model { get; set; }
+
+    [Parameter]
+    public string? Style { get; set; }
 
     [Parameter]
     public Typo? Typo { get; set; }

--- a/src/Arkanis.Overlay.Components/Shared/Tooltip.razor
+++ b/src/Arkanis.Overlay.Components/Shared/Tooltip.razor
@@ -1,4 +1,5 @@
-<MudTooltip Placement="@Placement">
+<MudTooltip Placement="@Placement"
+            RootStyle="@Style">
     <TooltipContent>
         @if (TooltipContent is null)
         {
@@ -26,6 +27,9 @@
 
     [Parameter]
     public string? Text { get; set; }
+
+    [Parameter]
+    public string? Style { get; set; }
 
     [Parameter]
     public Placement Placement { get; set; } = Placement.Top;

--- a/src/Arkanis.Overlay.Components/Views/Components/PriceTagTable.razor
+++ b/src/Arkanis.Overlay.Components/Views/Components/PriceTagTable.razor
@@ -43,7 +43,35 @@
                 <MudTd>
                     @if (priceTag is KnownPriceTagWithLocation priceTagWithLocation)
                     {
-                        <GameLocationLabel Model="@priceTagWithLocation.Location"/>
+                        <MudStack AlignItems="@AlignItems.Center"
+                                  Justify="@Justify.SpaceBetween"
+                                  Spacing="1"
+                                  Row>
+                            <GameLocationLabel Model="@priceTagWithLocation.Location"/>
+                            @if (SearchContext?.CurrentLocation is { } location)
+                            {
+                                if (location.IsOrContains(priceTagWithLocation.Location))
+                                {
+                                    <Tooltip Text="Within filtered location"
+                                             Style="height: 20px">
+                                        <MudIcon
+                                            Size="@Size.Small"
+                                            Icon="@Icons.Material.Filled.LocationOn"
+                                            Color="@Color.Success"/>
+                                    </Tooltip>
+                                }
+                                else
+                                {
+                                    <Tooltip Text="Not within filtered location"
+                                             Style="height: 20px">
+                                        <MudIcon
+                                            Size="@Size.Small"
+                                            Icon="@Icons.Material.Filled.LocationOff"
+                                            Color="@Color.Default"/>
+                                    </Tooltip>
+                                }
+                            }
+                        </MudStack>
                     }
                     else
                     {
@@ -82,6 +110,9 @@
 
 @code
 {
+
+    [CascadingParameter]
+    public OverlaySearchContext? SearchContext { get; set; }
 
     [Parameter]
     [EditorRequired]

--- a/src/Arkanis.Overlay.Domain/Abstractions/Game/IGameLocation.cs
+++ b/src/Arkanis.Overlay.Domain/Abstractions/Game/IGameLocation.cs
@@ -17,6 +17,8 @@ public interface IGameLocation : IGameEntity, ISearchableRecursively
     ISearchableRecursively? ISearchableRecursively.Parent
         => ParentLocation;
 
+    IEnumerable<GameLocationEntity> CreatePathToRoot();
+
     bool IsOrContains(IGameLocation location)
         => Id == location.Id || Contains(location);
 


### PR DESCRIPTION
Building upon feedback https://discord.com/channels/1294685596991750277/1374832046731432016/1374832046731432016
- when filtering by location, indicate which terminals are at or within the filtered location by an icon
- this is not displayed at all without a location filter active
- improve tooltips of the codified location names to contain the whole parent path instead of just full location name