### PR TITLE
fix: remove forgotten and unnecessary rendermode

### DIFF
--- a/src/Arkanis.Overlay.Host.Desktop/UI/Pages/TradePage.razor
+++ b/src/Arkanis.Overlay.Host.Desktop/UI/Pages/TradePage.razor
@@ -8,7 +8,6 @@
 
 <div>
     <TradeView
-        @rendermode="@(new InteractiveServerRenderMode(false))"
         @bind-ActiveTab:get="@TargetTab"
         @bind-ActiveTab:set="@UpdateTab"/>
 </div>


### PR DESCRIPTION
Fixes #355

Led to a crash on Desktop since different render modes are not supported there.