### PR TITLE
feat: change default hotkey & improve hotkey configuration input handling

### DIFF
--- a/src/Arkanis.Overlay.Components/Helpers/KeyboardShortcutBuilder.cs
+++ b/src/Arkanis.Overlay.Components/Helpers/KeyboardShortcutBuilder.cs
@@ -56,7 +56,7 @@ public sealed class KeyboardShortcutBuilder : IDisposable
         Value = KeyboardShortcut.None;
     }
 
-    public void AddKey(KeyboardEventArgs eventArgs)
+    public void KeyPressed(KeyboardEventArgs eventArgs)
     {
         var keyboardKey = eventArgs.GetKey();
         AddKey(keyboardKey);
@@ -89,7 +89,7 @@ public sealed class KeyboardShortcutBuilder : IDisposable
         }
     }
 
-    public void RemoveKey(KeyboardEventArgs eventArgs)
+    public void KeyReleased(KeyboardEventArgs eventArgs)
     {
         var keyboardKey = eventArgs.GetKey();
         RemoveKey(keyboardKey);

--- a/src/Arkanis.Overlay.Components/Services/KeyboardProxy.cs
+++ b/src/Arkanis.Overlay.Components/Services/KeyboardProxy.cs
@@ -77,10 +77,10 @@ public class KeyboardProxy : IDisposable, IKeyboardProxy
 
     private void ExtendShortcut(KeyboardEventArgs keyboardEvent)
     {
-        ShortcutBuilder.AddKey(keyboardEvent);
+        ShortcutBuilder.KeyPressed(keyboardEvent);
         RegisterKeyboardShortcut(ShortcutBuilder.Value.Copy());
     }
 
     private void StripShortcut(KeyboardEventArgs keyboardEvent)
-        => ShortcutBuilder.RemoveKey(keyboardEvent);
+        => ShortcutBuilder.KeyReleased(keyboardEvent);
 }

--- a/src/Arkanis.Overlay.Components/Shared/KeyboardShortcutInput.razor
+++ b/src/Arkanis.Overlay.Components/Shared/KeyboardShortcutInput.razor
@@ -69,7 +69,7 @@
 
     private async Task OnKeyDown(KeyboardEventArgs eventArgs)
     {
-        _shortcutBuilder!.AddKey(eventArgs);
+        _shortcutBuilder!.KeyPressed(eventArgs);
         await UpdateValueAsync(_shortcutBuilder.Value);
     }
 

--- a/src/Arkanis.Overlay.Components/Shared/KeyboardShortcutInput.razor
+++ b/src/Arkanis.Overlay.Components/Shared/KeyboardShortcutInput.razor
@@ -73,8 +73,11 @@
         await UpdateValueAsync(_shortcutBuilder.Value);
     }
 
-    private void OnKeyUp(KeyboardEventArgs eventArgs)
-        => _shortcutBuilder!.RemoveKey(eventArgs.GetKey());
+    private async Task OnKeyUp(KeyboardEventArgs eventArgs)
+    {
+        _shortcutBuilder!.RemoveKey(eventArgs.GetKey());
+        await UpdateValueAsync(_shortcutBuilder.Value);
+    }
 
     private async Task UpdatedAsync(KeyboardShortcut shortcut)
         => await InvokeAsync(() => UpdateValueAsync(shortcut));

--- a/src/Arkanis.Overlay.Domain/Models/Keyboard/KeyboardKeyUtils.cs
+++ b/src/Arkanis.Overlay.Domain/Models/Keyboard/KeyboardKeyUtils.cs
@@ -47,6 +47,18 @@ public static class KeyboardKeyUtils
         KeyboardKey.F10,
         KeyboardKey.F11,
         KeyboardKey.F12,
+        KeyboardKey.F13,
+        KeyboardKey.F14,
+        KeyboardKey.F15,
+        KeyboardKey.F16,
+        KeyboardKey.F17,
+        KeyboardKey.F18,
+        KeyboardKey.F19,
+        KeyboardKey.F20,
+        KeyboardKey.F21,
+        KeyboardKey.F22,
+        KeyboardKey.F23,
+        KeyboardKey.F24,
     ];
 
     private static readonly HashSet<KeyboardKey> AlphanumericKeys =
@@ -285,11 +297,11 @@ public static class KeyboardKeyUtils
             KeyboardKeyCategory.Lock => LockKeys,
             KeyboardKeyCategory.Navigation => NavigationKeys,
             KeyboardKeyCategory.Editing => EditingKeys,
-            KeyboardKeyCategory.Function => FunctionKeys,
+            KeyboardKeyCategory.Function => FunctionKeys, // standalone
             KeyboardKeyCategory.Alphanumeric => AlphanumericKeys,
             KeyboardKeyCategory.Numpad => NumpadKeys,
             KeyboardKeyCategory.Symbol => SymbolKeys,
-            KeyboardKeyCategory.Media => MediaKeys,
+            KeyboardKeyCategory.Media => MediaKeys, // standalone
             KeyboardKeyCategory.Whitespace => WhitespaceKeys,
             _ => [],
         };


### PR DESCRIPTION
- shortcut is locked in once first non-modifier is released
- default finalization timeout is set to 0
- finalization invoked immediately when timeout is 0 to fix incorrect shortcut due to event dispatch delay
- can dynamically add or remove modifiers while shortcut is not yet finalized
- add missing F keys (F13-F24)