### PR TITLE
Properly use resilience pipeline per-request for UEX API

### DIFF
--- a/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexCitySyncRepository.cs
+++ b/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexCitySyncRepository.cs
@@ -7,6 +7,7 @@ using Domain.Models.Game;
 using External.UEX.Abstractions;
 using Local;
 using Microsoft.Extensions.Logging;
+using Polly;
 using Services;
 
 internal class UexCitySyncRepository(
@@ -26,9 +27,15 @@ internal class UexCitySyncRepository(
     protected override double CacheTimeFactor
         => 7;
 
-    protected override async Task<UexApiResponse<ICollection<UniverseCityDTO>>> GetInternalResponseAsync(CancellationToken cancellationToken)
+    protected override async Task<UexApiResponse<ICollection<UniverseCityDTO>>> GetInternalResponseAsync(
+        ResiliencePipeline pipeline,
+        CancellationToken cancellationToken
+    )
     {
-        var response = await gameApi.GetCitiesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        var response = await pipeline.ExecuteAsync(
+            async ct => await gameApi.GetCitiesAsync(cancellationToken: ct).ConfigureAwait(false),
+            cancellationToken
+        );
         return CreateResponse(response, response.Result.Data?.Where(x => x.Is_available > 0).ToList());
     }
 

--- a/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexItemPriceSyncRepository.cs
+++ b/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexItemPriceSyncRepository.cs
@@ -7,6 +7,7 @@ using Domain.Models.Game;
 using External.UEX.Abstractions;
 using Local;
 using Microsoft.Extensions.Logging;
+using Polly;
 using Services;
 
 internal class UexItemPriceSyncRepository(
@@ -24,9 +25,15 @@ internal class UexItemPriceSyncRepository(
     protected override IDependable GetDependencies()
         => dependencyResolver.DependsOn<GameTerminal>(this);
 
-    protected override async Task<UexApiResponse<ICollection<ItemPriceBriefDTO>>> GetInternalResponseAsync(CancellationToken cancellationToken)
+    protected override async Task<UexApiResponse<ICollection<ItemPriceBriefDTO>>> GetInternalResponseAsync(
+        ResiliencePipeline pipeline,
+        CancellationToken cancellationToken
+    )
     {
-        var response = await itemsApi.GetItemsPricesAllAsync(cancellationToken).ConfigureAwait(false);
+        var response = await pipeline.ExecuteAsync(
+            async ct => await itemsApi.GetItemsPricesAllAsync(cancellationToken: ct).ConfigureAwait(false),
+            cancellationToken
+        );
         return CreateResponse(response, response.Result.Data);
     }
 

--- a/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexPlanetSyncRepository.cs
+++ b/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexPlanetSyncRepository.cs
@@ -7,6 +7,7 @@ using Domain.Models.Game;
 using External.UEX.Abstractions;
 using Local;
 using Microsoft.Extensions.Logging;
+using Polly;
 using Services;
 
 internal class UexPlanetSyncRepository(
@@ -24,9 +25,15 @@ internal class UexPlanetSyncRepository(
     protected override double CacheTimeFactor
         => 7;
 
-    protected override async Task<UexApiResponse<ICollection<UniversePlanetDTO>>> GetInternalResponseAsync(CancellationToken cancellationToken)
+    protected override async Task<UexApiResponse<ICollection<UniversePlanetDTO>>> GetInternalResponseAsync(
+        ResiliencePipeline pipeline,
+        CancellationToken cancellationToken
+    )
     {
-        var response = await gameApi.GetPlanetsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        var response = await pipeline.ExecuteAsync(
+            async ct => await gameApi.GetPlanetsAsync(cancellationToken: ct).ConfigureAwait(false),
+            cancellationToken
+        );
         return CreateResponse(response, response.Result.Data?.Where(x => x.Is_available > 0).ToList());
     }
 

--- a/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexProductCategorySyncRepository.cs
+++ b/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexProductCategorySyncRepository.cs
@@ -6,6 +6,7 @@ using Domain.Models.Game;
 using External.UEX.Abstractions;
 using Local;
 using Microsoft.Extensions.Logging;
+using Polly;
 
 internal class UexProductCategorySyncRepository(
     IUexGameApi gameApi,
@@ -15,9 +16,15 @@ internal class UexProductCategorySyncRepository(
     ILogger<UexProductCategorySyncRepository> logger
 ) : UexGameEntitySyncRepositoryBase<CategoryDTO, GameProductCategory>(stateProvider, cacheProvider, mapper, logger)
 {
-    protected override async Task<UexApiResponse<ICollection<CategoryDTO>>> GetInternalResponseAsync(CancellationToken cancellationToken)
+    protected override async Task<UexApiResponse<ICollection<CategoryDTO>>> GetInternalResponseAsync(
+        ResiliencePipeline pipeline,
+        CancellationToken cancellationToken
+    )
     {
-        var response = await gameApi.GetCategoriesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        var response = await pipeline.ExecuteAsync(
+            async ct => await gameApi.GetCategoriesAsync(cancellationToken: ct).ConfigureAwait(false),
+            cancellationToken
+        );
         return CreateResponse(response, response.Result.Data);
     }
 

--- a/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexSharedResiliency.cs
+++ b/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexSharedResiliency.cs
@@ -1,0 +1,37 @@
+namespace Arkanis.Overlay.Infrastructure.Repositories.Sync;
+
+using System.Threading.RateLimiting;
+using Polly;
+using Polly.Retry;
+
+public static class UexSharedResiliency
+{
+    public const int ApiRequestBatchSize = 10;
+
+    public const int MaxQueueSize = 1_000;
+    private static readonly TimeSpan TrackedWindow = TimeSpan.FromSeconds(10);
+
+    private static readonly RateLimiter RateLimiter = new SlidingWindowRateLimiter(
+        new SlidingWindowRateLimiterOptions
+        {
+            Window = TrackedWindow,
+            PermitLimit = 50,
+            QueueLimit = MaxQueueSize,
+            SegmentsPerWindow = 4,
+            AutoReplenishment = true,
+        }
+    );
+
+    private static RetryStrategyOptions RetryOptions { get; } = new()
+    {
+        Delay = TrackedWindow / 2,
+        BackoffType = DelayBackoffType.Linear,
+        MaxRetryAttempts = 4,
+    };
+
+    public static readonly ResiliencePipeline Pipeline = new ResiliencePipelineBuilder()
+        .AddRetry(RetryOptions)
+        .AddConcurrencyLimiter(5, MaxQueueSize)
+        .AddRateLimiter(RateLimiter)
+        .Build();
+}

--- a/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexSpaceShipSyncRepository.cs
+++ b/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexSpaceShipSyncRepository.cs
@@ -7,6 +7,7 @@ using Domain.Models.Game;
 using External.UEX.Abstractions;
 using Local;
 using Microsoft.Extensions.Logging;
+using Polly;
 using Services;
 
 internal class UexSpaceShipSyncRepository(
@@ -21,9 +22,15 @@ internal class UexSpaceShipSyncRepository(
     protected override IDependable GetDependencies()
         => dependencyResolver.DependsOn<GameCompany>(this);
 
-    protected override async Task<UexApiResponse<ICollection<VehicleDTO>>> GetInternalResponseAsync(CancellationToken cancellationToken)
+    protected override async Task<UexApiResponse<ICollection<VehicleDTO>>> GetInternalResponseAsync(
+        ResiliencePipeline pipeline,
+        CancellationToken cancellationToken
+    )
     {
-        var response = await gameApi.GetVehiclesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        var response = await pipeline.ExecuteAsync(
+            async ct => await gameApi.GetVehiclesAsync(cancellationToken: ct).ConfigureAwait(false),
+            cancellationToken
+        );
         return CreateResponse(response, response.Result.Data);
     }
 

--- a/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexSpaceStationSyncRepository.cs
+++ b/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexSpaceStationSyncRepository.cs
@@ -7,6 +7,7 @@ using Domain.Models.Game;
 using External.UEX.Abstractions;
 using Local;
 using Microsoft.Extensions.Logging;
+using Polly;
 using Services;
 
 internal class UexSpaceStationSyncRepository(
@@ -27,9 +28,15 @@ internal class UexSpaceStationSyncRepository(
     protected override double CacheTimeFactor
         => 7;
 
-    protected override async Task<UexApiResponse<ICollection<UniverseSpaceStationDTO>>> GetInternalResponseAsync(CancellationToken cancellationToken)
+    protected override async Task<UexApiResponse<ICollection<UniverseSpaceStationDTO>>> GetInternalResponseAsync(
+        ResiliencePipeline pipeline,
+        CancellationToken cancellationToken
+    )
     {
-        var response = await gameApi.GetSpaceStationsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        var response = await pipeline.ExecuteAsync(
+            async ct => await gameApi.GetSpaceStationsAsync(cancellationToken: ct).ConfigureAwait(false),
+            cancellationToken
+        );
         return CreateResponse(response, response.Result.Data?.Where(x => x.Is_available > 0).ToList());
     }
 

--- a/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexTerminalSyncRepository.cs
+++ b/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexTerminalSyncRepository.cs
@@ -7,6 +7,7 @@ using Domain.Models.Game;
 using External.UEX.Abstractions;
 using Local;
 using Microsoft.Extensions.Logging;
+using Polly;
 using Services;
 
 internal class UexTerminalSyncRepository(
@@ -24,9 +25,15 @@ internal class UexTerminalSyncRepository(
             .AlsoDependsOn<GameOutpost>()
             .AlsoDependsOn<GameSpaceStation>();
 
-    protected override async Task<UexApiResponse<ICollection<UniverseTerminalDTO>>> GetInternalResponseAsync(CancellationToken cancellationToken)
+    protected override async Task<UexApiResponse<ICollection<UniverseTerminalDTO>>> GetInternalResponseAsync(
+        ResiliencePipeline pipeline,
+        CancellationToken cancellationToken
+    )
     {
-        var response = await gameApi.GetTerminalsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        var response = await pipeline.ExecuteAsync(
+            async ct => await gameApi.GetTerminalsAsync(cancellationToken: ct).ConfigureAwait(false),
+            cancellationToken
+        );
         return CreateResponse(response, response.Result.Data?.Where(x => x.Is_available > 0).ToList());
     }
 

--- a/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexVehiclePurchasePriceSyncRepository.cs
+++ b/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexVehiclePurchasePriceSyncRepository.cs
@@ -7,6 +7,7 @@ using Domain.Models.Game;
 using External.UEX.Abstractions;
 using Local;
 using Microsoft.Extensions.Logging;
+using Polly;
 using Services;
 
 internal class UexVehiclePurchasePriceSyncRepository(
@@ -21,9 +22,15 @@ internal class UexVehiclePurchasePriceSyncRepository(
     protected override IDependable GetDependencies()
         => dependencyResolver.DependsOn<GameTerminal>(this);
 
-    protected override async Task<UexApiResponse<ICollection<VehiclePurchasePriceBriefDTO>>> GetInternalResponseAsync(CancellationToken cancellationToken)
+    protected override async Task<UexApiResponse<ICollection<VehiclePurchasePriceBriefDTO>>> GetInternalResponseAsync(
+        ResiliencePipeline pipeline,
+        CancellationToken cancellationToken
+    )
     {
-        var response = await vehiclesApi.GetVehiclesPurchasesPricesAllAsync(cancellationToken).ConfigureAwait(false);
+        var response = await pipeline.ExecuteAsync(
+            async ct => await vehiclesApi.GetVehiclesPurchasesPricesAllAsync(cancellationToken: ct).ConfigureAwait(false),
+            cancellationToken
+        );
         return CreateResponse(response, response.Result.Data);
     }
 

--- a/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexVehicleRentPriceSyncRepository.cs
+++ b/src/Arkanis.Overlay.Infrastructure/Repositories/Sync/UexVehicleRentPriceSyncRepository.cs
@@ -7,6 +7,7 @@ using Domain.Models.Game;
 using External.UEX.Abstractions;
 using Local;
 using Microsoft.Extensions.Logging;
+using Polly;
 using Services;
 
 internal class UexVehicleRentPriceSyncRepository(
@@ -21,9 +22,15 @@ internal class UexVehicleRentPriceSyncRepository(
     protected override IDependable GetDependencies()
         => dependencyResolver.DependsOn<GameTerminal>(this);
 
-    protected override async Task<UexApiResponse<ICollection<VehicleRentalPriceBriefDTO>>> GetInternalResponseAsync(CancellationToken cancellationToken)
+    protected override async Task<UexApiResponse<ICollection<VehicleRentalPriceBriefDTO>>> GetInternalResponseAsync(
+        ResiliencePipeline pipeline,
+        CancellationToken cancellationToken
+    )
     {
-        var response = await vehiclesApi.GetVehiclesRentalsPricesAllAsync(cancellationToken).ConfigureAwait(false);
+        var response = await pipeline.ExecuteAsync(
+            async ct => await vehiclesApi.GetVehiclesRentalsPricesAllAsync(cancellationToken: ct).ConfigureAwait(false),
+            cancellationToken
+        );
         return CreateResponse(response, response.Result.Data);
     }
 


### PR DESCRIPTION
The resilience pipeline was previously used on the whole "set" of requests which made things in fact worse.