### PR TITLE
build: enable windows targeting in csproj files

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -56,7 +56,7 @@ jobs:
       - run: echo "Cache hit - ${{ steps.setup-dotnet.outputs.cache-hit }}"
 
       - name: Restore dependencies
-        run: dotnet restore --locked-mode -p:EnableWindowsTargeting=true
+        run: dotnet restore --locked-mode
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/renovate.json
+++ b/renovate.json
@@ -15,8 +15,7 @@
     },
     "packageRules": [
         {
-            "matchDatasources": ["nuget"],
-            "postUpdateOptions": ["dotnetEnableWindowsTargeting"]
+            "matchDatasources": ["nuget"]
         }
     ]
 }

--- a/scripts/release-11-verify-win64.sh
+++ b/scripts/release-11-verify-win64.sh
@@ -16,7 +16,6 @@ dotnet publish ./src/Arkanis.Overlay.Host.Desktop/Arkanis.Overlay.Host.Desktop.c
     --runtime win-x64 \
     --configuration "${CONFIGURATION}" \
     --output publish-win64 \
-    -p:EnableWindowsTargeting=true \
     -p:DebugType=None \
     -p:DebugSymbols=false \
     1>&2 # logging output must not go to stdout

--- a/src/Arkanis.Overlay.Host.Desktop/Arkanis.Overlay.Host.Desktop.csproj
+++ b/src/Arkanis.Overlay.Host.Desktop/Arkanis.Overlay.Host.Desktop.csproj
@@ -15,6 +15,9 @@
         <ServerGarbageCollection>false</ServerGarbageCollection>
         <PackageId>Arkanis.Overlay.Host.Desktop</PackageId>
         <AssemblyName>ArkanisOverlay</AssemblyName>
+
+        <!-- Allow building on non-windows platforms -->
+        <EnableWindowsTargeting>true</EnableWindowsTargeting>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/tests/Arkanis.Overlay.Host.Desktop.UnitTests/Arkanis.Overlay.Host.Desktop.UnitTests.csproj
+++ b/tests/Arkanis.Overlay.Host.Desktop.UnitTests/Arkanis.Overlay.Host.Desktop.UnitTests.csproj
@@ -7,6 +7,9 @@
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
+
+        <!-- Allow building on non-windows platforms -->
+        <EnableWindowsTargeting>true</EnableWindowsTargeting>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Moves the `EnableWindowsTargeting` option from CLI switch to the affected projects