### PR TITLE
Use entity name as default string representation

### DIFF
--- a/src/Arkanis.Overlay.Components/Shared/GameEntitySelectBox.razor
+++ b/src/Arkanis.Overlay.Components/Shared/GameEntitySelectBox.razor
@@ -117,17 +117,6 @@
         _only = Only?.ToHashSet(IIdentifiable.EqualityComparer.For<IGameLocation>());
     }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        await base.OnAfterRenderAsync(firstRender);
-
-        if (_field?.Text != Text)
-        {
-            // force field to update initially coerced display text for default values
-            await _field!.ForceUpdate();
-        }
-    }
-
     private async Task<IEnumerable<IGameEntity?>> FindEntitiesAsync(string? searchText, CancellationToken ct)
     {
         IEnumerable<SearchQuery> queries = [];

--- a/src/Arkanis.Overlay.Domain/Models/Game/GameEntity.cs
+++ b/src/Arkanis.Overlay.Domain/Models/Game/GameEntity.cs
@@ -21,4 +21,7 @@ public abstract class GameEntity(UexApiGameEntityId id, GameEntityCategory entit
     {
         yield return new SearchableEntityCategory(EntityCategory);
     }
+
+    public override string ToString()
+        => Name.MainContent.FullName;
 }


### PR DESCRIPTION
I have done what should have been done a long time ago - instead of fighting with stupidness of MudBlazor autocomplete, let's just embrace entity names as their default string representations.

This _finally_ fixes the entity select boxes. Both them recently freezing the UI and showing up bullcrap :)