### PR TITLE
Allow searching entries based on their nicknames/short names

### DIFF
--- a/src/Arkanis.Overlay.Domain/Models/Game/GameOutpost.cs
+++ b/src/Arkanis.Overlay.Domain/Models/Game/GameOutpost.cs
@@ -17,6 +17,7 @@ public sealed class GameOutpost(int id, string fullName, string shortName, GameL
     protected override IEnumerable<SearchableTrait> CollectSearchableTraits()
     {
         yield return new SearchableName(fullName);
+        yield return new SearchableName(shortName);
         foreach (var searchableAttribute in base.CollectSearchableTraits())
         {
             yield return searchableAttribute;

--- a/src/Arkanis.Overlay.Domain/Models/Game/GameSpaceStation.cs
+++ b/src/Arkanis.Overlay.Domain/Models/Game/GameSpaceStation.cs
@@ -17,6 +17,7 @@ public sealed class GameSpaceStation(int id, string fullName, string shortName, 
     protected override IEnumerable<SearchableTrait> CollectSearchableTraits()
     {
         yield return new SearchableName(fullName);
+        yield return new SearchableName(shortName);
         foreach (var searchableAttribute in base.CollectSearchableTraits())
         {
             yield return searchableAttribute;

--- a/src/Arkanis.Overlay.Domain/Models/Game/GameTerminal.cs
+++ b/src/Arkanis.Overlay.Domain/Models/Game/GameTerminal.cs
@@ -39,6 +39,7 @@ public sealed class GameTerminal(
     protected override IEnumerable<SearchableTrait> CollectSearchableTraits()
     {
         yield return new SearchableName(fullName);
+        yield return new SearchableName(shortName);
         yield return new SearchableCode(codeName);
         foreach (var searchableAttribute in base.CollectSearchableTraits())
         {

--- a/src/Arkanis.Overlay.Domain/Models/Game/GameVehicle.cs
+++ b/src/Arkanis.Overlay.Domain/Models/Game/GameVehicle.cs
@@ -62,6 +62,7 @@ public abstract class GameVehicle(
     protected override IEnumerable<SearchableTrait> CollectSearchableTraits()
     {
         yield return new SearchableName(fullName);
+        yield return new SearchableName(shortName);
         yield return new SearchableManufacturer(manufacturer);
         foreach (var searchableAttribute in base.CollectSearchableTraits())
         {


### PR DESCRIPTION
- "Grim HEX" is one of the examples
- searching for "grimhex" still doesn't work because of the space
  - should that be addressed as well?

<img width="1492" height="1016" alt="image" src="https://github.com/user-attachments/assets/9c2efb31-3148-4972-a7e3-669a67c49c9c" />

Resolves #382 