### PR TITLE
Display warning about the shared nature of server hosted environment near account link configuration

### DIFF
--- a/src/Arkanis.Overlay.Components/Shared/ExternalAccountControls.razor
+++ b/src/Arkanis.Overlay.Components/Shared/ExternalAccountControls.razor
@@ -1,4 +1,18 @@
+@using Arkanis.Overlay.Infrastructure.Options
+@using Microsoft.Extensions.Options
+@inject IOptions<InfrastructureServiceOptions> ServiceOptions
+
 <MudExpansionPanels>
+    @if (ServiceOptions.Value.HostingMode is HostingMode.Server)
+    {
+        <MudAlert Severity="@Severity.Error">
+            <b>Do not link your personal accounts!</b>
+            This is a publicly available and shared instance.
+            Other users <u>will be able</u> to use features using linked accounts <u>on behalf of your accounts</u>.
+        </MudAlert>
+        <MudDivider/>
+    }
+
     <CitizenIdServiceSettingsPanel
         ContentId="@ContentId"/>
 

--- a/src/Arkanis.Overlay.Infrastructure/DependencyInjection.cs
+++ b/src/Arkanis.Overlay.Infrastructure/DependencyInjection.cs
@@ -47,6 +47,7 @@ public static class DependencyInjection
             }
         );
 
+        services.Configure(configure);
         var options = new InfrastructureServiceOptions();
         configure(options);
 
@@ -138,9 +139,4 @@ public static class DependencyInjection
     public static IServiceCollection AddInfrastructureConfiguration(this IServiceCollection services, IConfiguration configuration)
         => services
             .AddConfiguration<ConfigurationOptions>(configuration);
-
-    public class InfrastructureServiceOptions
-    {
-        public HostingMode HostingMode { get; set; }
-    }
 }

--- a/src/Arkanis.Overlay.Infrastructure/Options/InfrastructureServiceOptions.cs
+++ b/src/Arkanis.Overlay.Infrastructure/Options/InfrastructureServiceOptions.cs
@@ -1,0 +1,8 @@
+namespace Arkanis.Overlay.Infrastructure.Options;
+
+using Common.Enums;
+
+public class InfrastructureServiceOptions
+{
+    public HostingMode HostingMode { get; set; }
+}


### PR DESCRIPTION
I have unlinked personal user accounts from the demo on more than one occasion, so for obvious reasons, I decided to add a warning about the instance being shared.

<img width="1283" height="907" alt="image" src="https://github.com/user-attachments/assets/edab574b-c6d7-4193-90a0-8cc1a4a3ce9a" />
