### PR TITLE
fix: add save & cancel buttons to user preferences in settings menu

### DIFF
--- a/src/Arkanis.Overlay.Components/Shared/UserPreferencesControls.razor
+++ b/src/Arkanis.Overlay.Components/Shared/UserPreferencesControls.razor
@@ -120,6 +120,15 @@
                             @bind-Value:after="@ValidateAsync"
                             Required/>
                     </MudItem>
+                    @if (ShowSaveCancelButtons)
+                    {
+                        <MudItem xs="12">
+                            <MudStack Justify="Justify.FlexEnd" Row>
+                                <MudButton OnClick="@Cancel">Cancel</MudButton>
+                                <MudButton Color="@Color.Success" OnClick="@SaveAsync" Disabled="@(!IsValid)">Save</MudButton>
+                            </MudStack>
+                        </MudItem>
+                    }
                 </MudGrid>
             </MudForm>
         </ChildContent>
@@ -136,7 +145,6 @@
 
 @code
 {
-
     private MudForm? _form;
 
     private static readonly CultureInfo[] Cultures = CultureInfo.GetCultures(CultureTypes.NeutralCultures)
@@ -170,6 +178,9 @@
     [Parameter]
     public bool ExpandInitially { get; set; }
 
+    [Parameter]
+    public bool ShowSaveCancelButtons { get; set; }
+
     private async Task ValidateAsync()
     {
         if (_form is not null)
@@ -187,4 +198,22 @@
     private Task<IEnumerable<RegionInfo>> SearchRegion(string? searchTerm, CancellationToken ct)
         => Task.FromResult(Regions.FuzzySearch(culture => culture.EnglishName, searchTerm ?? string.Empty));
 
+    private async Task SaveAsync()
+    {
+        if (!IsValid)
+        {
+            return;
+        }
+
+        await UserPreferencesManager.SaveAndApplyUserPreferencesAsync(Preferences);
+        // reset validity state to disable save button until next change
+        IsValid = false;
+    }
+
+    private void Cancel()
+    {
+        Preferences = UserPreferencesManager.CurrentPreferences with { };
+        // reset validity state to disable save button until next change
+        IsValid = false;
+    }
 }

--- a/src/Arkanis.Overlay.Components/Views/SettingsView.razor
+++ b/src/Arkanis.Overlay.Components/Views/SettingsView.razor
@@ -45,8 +45,9 @@
                 <MudDivider/>
 
                 <UserPreferencesControls
-                    Preferences="@UserPreferencesManager.CurrentPreferences"
-                    @bind-IsValid="@_isValid"/>
+                    Preferences="@_preferences"
+                    @bind-IsValid="@_isValid"
+                    ShowSaveCancelButtons/>
             </MudPaper>
 
             <MudPaper>
@@ -70,6 +71,7 @@
 
 @code
 {
+    private UserPreferences _preferences = new();
 
     private const string ContentId = "settings";
 
@@ -91,6 +93,9 @@
     {
         UserPreferencesManager.ApplyPreferences += PerformUpdate;
     }
+
+    protected override void OnParametersSet()
+        => _preferences = UserPreferencesManager.CurrentPreferences with { };
 
     public void Dispose()
     {


### PR DESCRIPTION
Adds `Save` & `Cancel` buttons to the User Preferences section of the Overlay's Settings menu.

Resolves #499 and resolves #500 .

This slightly duplicates the logic in the `UserPreferencesDialog` but avoids the overhead of reworking the logic into a shared wrapper.