### PR TITLE
fix: custom protocol handler URL slug update

### DIFF
--- a/src/Arkanis.Overlay.Common/ApplicationConstants.cs
+++ b/src/Arkanis.Overlay.Common/ApplicationConstants.cs
@@ -47,9 +47,10 @@ public static class ApplicationConstants
     {
         private const string AppName = "Overlay";
 
-        public const string Schema = $"{Company.Slug}-{AppName}";
+        public const string OldSchema = $"{Company.Slug}-{AppName}";
+        public static readonly string Schema = $"{Company.Slug}-{AppName}".ToLowerInvariant();
 
-        private static readonly Uri BaseUri = new($"{Schema.ToLowerInvariant()}://");
+        private static readonly Uri BaseUri = new($"{Schema}://");
 
         public static Uri CreateUriFor(string path)
             => new(BaseUri, path);

--- a/src/Arkanis.Overlay.Host.Desktop/Services/WindowsCustomProtocolHandlerManager.cs
+++ b/src/Arkanis.Overlay.Host.Desktop/Services/WindowsCustomProtocolHandlerManager.cs
@@ -12,7 +12,16 @@ public class WindowsCustomProtocolHandlerManager(
     ILogger<WindowsCustomProtocolHandlerManager> logger
 ) : IHostedService
 {
-    private const string ProtocolHandlerKeyPath = @$"Software\Classes\{ApplicationConstants.Protocol.Schema}";
+    /// <remarks>
+    /// Kept for backwards compatibility with older versions that used incorrect casing.
+    /// Used to clean up old registry entries.
+    /// </remarks>
+    private const string OldProtocolHandlerKeyPath = @$"Software\Classes\{ApplicationConstants.Protocol.OldSchema}";
+    /// <remarks>
+    /// The registry key path for our custom protocol handler.
+    /// Relative to <c>HKEY_CURRENT_USER</c>.
+    /// </remarks>
+    private static readonly string ProtocolHandlerKeyPath = @$"Software\Classes\{ApplicationConstants.Protocol.Schema}";
 
     private const string ApplicationKeySubPath = "Application";
     private const string HandlerKeySubPath = @"shell\open\command";
@@ -42,6 +51,10 @@ public class WindowsCustomProtocolHandlerManager(
     /// </summary>
     private static void EnableProtocolHandler()
     {
+        // Clean up any existing keys with incorrect casing
+        using var oldProtocolHandlerKey = Registry.CurrentUser.OpenSubKey(OldProtocolHandlerKeyPath, true);
+        oldProtocolHandlerKey?.DeleteSubKeyTree("");
+
         using var protocolHandlerKey = Registry.CurrentUser.OpenSubKey(ProtocolHandlerKeyPath, true)
                                        ?? Registry.CurrentUser.CreateSubKey(ProtocolHandlerKeyPath);
 

--- a/src/Arkanis.Overlay.Host.Desktop/Services/WindowsCustomProtocolHandlerManager.cs
+++ b/src/Arkanis.Overlay.Host.Desktop/Services/WindowsCustomProtocolHandlerManager.cs
@@ -75,13 +75,8 @@ public class WindowsCustomProtocolHandlerManager(
     private static void DisableProtocolHandler()
     {
         using var protocolHandlerKey = Registry.CurrentUser.OpenSubKey(ProtocolHandlerKeyPath, true);
-        if (protocolHandlerKey is null)
-        {
-            return;
-        }
 
-        protocolHandlerKey.DeleteValue(UrlProtocolKeyName);
-        protocolHandlerKey.DeleteSubKeyTree(HandlerKeySubPath);
+        protocolHandlerKey?.DeleteSubKeyTree("");
     }
 
     private void OnUserApplyPreferences(object? sender, UserPreferences userPreferences)


### PR DESCRIPTION
~~Potentially fixes issues with the custom protocol handler not working by changing the ProtocolHandlerKeyPath to be lower case.~~
Also changes disabling logic to fully clean up the registry.

Converted to draft because lower-casing turned out to be unnecessary.
Keeping since it can be re-used to update custom protocol URL to use a different slug.