### PR TITLE
ci: switch semantic release GITHUB_TOKEN to PAT to allow VirusTotal action to trigger

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -108,7 +108,7 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         id: semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}
           NUGET_PUBLISH_API_KEY: ${{ secrets.NUGET_PUBLISH_API_KEY }}
           DEBUG: ${{ inputs.dry_run && '*' || '' }}
         with:


### PR DESCRIPTION
The VirusTotal action we are using requires to be triggered using a release publish event in order for it to be able to scan the files attached to the release and then update the release with the scan results.

Using the provided `GITHUB_TOKEN` to publish the release apparently prevents this event from firing as some sort of recursion / abuse prevention.

This PR switches from using the provided token to a PAT provided as a secret.