### PR TITLE
ci: route CI jobs through RUNNER_DEFAULT/RUNNER_CLUSTER runner pools

### DIFF
--- a/.github/workflows/_deploy-coolify.yaml
+++ b/.github/workflows/_deploy-coolify.yaml
@@ -30,7 +30,7 @@ on:
         description: "Runner pool"
         required: false
         type: string
-        default: arkanis-runners
+        default: daedalus
     secrets:
       COOLIFY_URL:
         required: true

--- a/.github/workflows/_deploy-env.yaml
+++ b/.github/workflows/_deploy-env.yaml
@@ -15,9 +15,10 @@ on:
         description: "Runner pool (override to ubuntu-latest if self-hosted is broken)"
         type: choice
         options:
+          - daedalus
           - arkanis-runners
           - ubuntu-latest
-        default: arkanis-runners
+        default: daedalus
   workflow_call:
     inputs:
       image_ref:
@@ -27,7 +28,7 @@ on:
         description: "Runner pool"
         required: false
         type: string
-        default: arkanis-runners
+        default: daedalus
 
 jobs:
   deploy:
@@ -36,7 +37,7 @@ jobs:
     with:
       application_name: web demo
       environment_name: ${{ vars.COOLIFY_DEPLOY_ENVIRONMENT }}
-      runner: ${{ inputs.runner || 'arkanis-runners' }}
+      runner: ${{ inputs.runner || vars.RUNNER_DEFAULT || 'daedalus' }}
     secrets:
       COOLIFY_URL: ${{ secrets.COOLIFY_URL }}
       COOLIFY_DEPLOY_UUID: ${{ secrets.COOLIFY_DEPLOY_UUID }}

--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -14,9 +14,10 @@ on:
         description: "Runner pool (override to ubuntu-latest if self-hosted is broken)"
         type: choice
         options:
+          - daedalus
           - arkanis-runners
           - ubuntu-latest
-        default: arkanis-runners
+        default: daedalus
   workflow_call:
     inputs:
       dry_run:
@@ -28,7 +29,7 @@ on:
         description: "Runner pool"
         required: false
         type: string
-        default: arkanis-runners
+        default: daedalus
     outputs:
       new_version:
         description: "Newly published version"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,9 +15,10 @@ on:
         description: "Runner pool (override to ubuntu-latest if self-hosted is broken)"
         type: choice
         options:
+          - daedalus
           - arkanis-runners
           - ubuntu-latest
-        default: arkanis-runners
+        default: daedalus
 
 permissions:
   contents: write       # for publishing a GitHub release and creating release backpropagation PRs
@@ -42,7 +43,7 @@ jobs:
     secrets: inherit
     with:
       dry_run: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/ci' }}
-      runner: ${{ inputs.runner || 'arkanis-runners' }}
+      runner: ${{ inputs.runner || vars.RUNNER_DEFAULT || 'daedalus' }}
 
   # delpoyment target is selected by the active environment
   deploy:
@@ -56,4 +57,4 @@ jobs:
       application_name: web demo
       environment_name: ${{ vars.COOLIFY_DEPLOY_ENVIRONMENT }}
       gh_environment: Production
-      runner: ${{ inputs.runner || 'arkanis-runners' }}
+      runner: ${{ inputs.runner || vars.RUNNER_DEFAULT || 'daedalus' }}

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -14,13 +14,14 @@ on:
         description: "Runner pool (override to ubuntu-latest if self-hosted is broken)"
         type: choice
         options:
+          - daedalus
           - arkanis-runners
           - ubuntu-latest
-        default: arkanis-runners
+        default: daedalus
 
 jobs:
   virustotal:
-    runs-on: ${{ inputs.runner || 'arkanis-runners' }}
+    runs-on: ${{ inputs.runner || vars.RUNNER_DEFAULT || 'daedalus' }}
     permissions:
       # required to write GitHub Release body
       contents: write


### PR DESCRIPTION
## Summary

Route all self-hosted CI jobs through repo variables `RUNNER_DEFAULT` (`daedalus`) and `RUNNER_CLUSTER` (`arkanis-runners`) with literal fallbacks, eliminating the risk of an empty `runs-on` value when a variable is unset.

## Job classification table

| File | Job | Old `runs-on` / dispatch default | New | Pool |
|---|---|---|---|---|
| `_deploy-coolify.yaml` | `deploy` | `inputs.runner` (default: `arkanis-runners`) | `inputs.runner` (default: `daedalus`) | GENERAL — reusable wf; caller resolves |
| `_deploy-env.yaml` | `deploy` | caller `inputs.runner \|\| 'arkanis-runners'` | caller `inputs.runner \|\| vars.RUNNER_DEFAULT \|\| 'daedalus'` | GENERAL |
| `_release.yaml` | `release` | `inputs.runner` (default: `arkanis-runners`); dispatch default `arkanis-runners` | `inputs.runner` (default: `daedalus`); dispatch default `daedalus`; `daedalus` added to options | GENERAL — reusable wf; caller resolves |
| `build.yaml` | `release` | caller `inputs.runner \|\| 'arkanis-runners'` | caller `inputs.runner \|\| vars.RUNNER_DEFAULT \|\| 'daedalus'` | GENERAL |
| `build.yaml` | `deploy` | caller `inputs.runner \|\| 'arkanis-runners'` | caller `inputs.runner \|\| vars.RUNNER_DEFAULT \|\| 'daedalus'` | GENERAL |
| `on_release.yaml` | `virustotal` | `inputs.runner \|\| 'arkanis-runners'` | `inputs.runner \|\| vars.RUNNER_DEFAULT \|\| 'daedalus'` | GENERAL — direct job |
| `_test.yaml` | `test` | `windows-latest` | unchanged | GitHub-hosted — left as-is |

## GitHub-hosted candidates (not moved)

- `_test.yaml` `test`: `windows-latest` — intentionally GitHub-hosted; listed as candidate if cluster-local tooling is ever needed.

## Special cases / notes

- **`_release.yaml` buildkit conditionals preserved**: Steps "Set up Docker Buildx (remote BuildKit — self-hosted only)" and "Set up Docker Buildx (default — fallback runner)" remain gated on `inputs.runner == 'arkanis-runners'` / `inputs.runner != 'arkanis-runners'` exactly as before. The job is GENERAL; the conditionals select local vs remote buildkit based on the runner used at that run.
- **Repo variables set**: `RUNNER_DEFAULT=daedalus` and `RUNNER_CLUSTER=arkanis-runners` have been created in this repo. No RUNNER_CLUSTER jobs exist in this repo currently (all self-hosted jobs are GENERAL), but the variable is available for future use.
- **Branch note**: Branch uses `runner-routing/ci-pools` rather than `ci/runner-routing` to avoid a Git directory-file conflict with the existing remote `ci` branch.
- **Precedence shape**: manual dispatch input → repo variable → literal fallback — no `runs-on` can be empty.