### PR TITLE
ci: install Azure CLI in release job (azure/login needs az on daedalus)

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -62,6 +62,12 @@ jobs:
         with:
           fetch-tags: true
 
+      - name: Install Azure CLI
+        # azure/login and the Velopack code-signing token step shell out to `az` on
+        # the host; the daedalus pool (RUNNER_DEFAULT) does not ship it, so install it.
+        uses: elstudio/action-install-azure-cli@v1
+        if: env.ENABLE_CODE_SIGNING
+
       - name: Azure Login
         uses: azure/login@v3
         if: env.ENABLE_CODE_SIGNING


### PR DESCRIPTION
## Problem

After #601 standardized runner routing, the `release` job runs on the **daedalus** pool
(`RUNNER_DEFAULT`). The push-to-`main` release then failed at **Azure Login**:

```
Release / release — Azure Login
##[error]Login failed with Error: Unable to locate executable file: az.
```

`azure/login@v3` (and the Velopack code-signing token step) shell out to the **Azure CLI on
the host**, which `arkanis-runners` shipped but `daedalus` does not. The signing path is
gated on `ENABLE_CODE_SIGNING` (only `main` / `release/*` / `ci`), which is why PR checks
were green but the merge to `main` failed.

## Fix

Install the Azure CLI before `Azure Login`, using the org-standard
`elstudio/action-install-azure-cli@v1` (the same action `Infrastructure` uses), gated on
`ENABLE_CODE_SIGNING` so it only runs when signing actually runs.

## Verification

The signing path isn't exercised by PRs (signing is skipped off `main`/`release/*`/`ci`).
Verified via the `ci` branch, which enables signing while forcing `dry_run` (no publish) —
run linked in a comment below.

## Scope

Org-wide scan: ArkanisOverlay is the **only** runner-routed repo that uses `azure/login` /
host `az`. All other merged routing PRs are green on `main`, so this gap is isolated here.
