### PR TITLE
ci: install Node unconditionally in release job for self-hosted runners

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -136,10 +136,11 @@ jobs:
         # (daedalus / arkanis-runners) don't ship Node, so `npm` is missing and
         # the Semantic Release step fails with `npm: not found`. Install Node
         # unconditionally so the release runs deterministically on any runner.
-        # semantic-release 25 requires Node ^22.14 || >=24.10.
+        # Pin the current Active LTS (Node 24, EOL 2028-04); satisfies
+        # semantic-release 25's engine requirement (^22.14 || >=24.10).
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       # determines whether a new version release is mandated
       # if it is, publish scripts are run and new version is tagged and published

--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -130,6 +130,17 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: true
 
+      - name: Setup Node.js
+        # cycjimmy/semantic-release-action shells out to `npm ci` to install
+        # semantic-release and its plugins. The self-hosted runner pools
+        # (daedalus / arkanis-runners) don't ship Node, so `npm` is missing and
+        # the Semantic Release step fails with `npm: not found`. Install Node
+        # unconditionally so the release runs deterministically on any runner.
+        # semantic-release 25 requires Node ^22.14 || >=24.10.
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
       # determines whether a new version release is mandated
       # if it is, publish scripts are run and new version is tagged and published
       - name: Semantic Release


### PR DESCRIPTION
## Summary

The release job's `Semantic Release` step (`cycjimmy/semantic-release-action`) shells out to `npm ci` to install semantic-release and its plugins. The self-hosted runner pools (`daedalus` / `arkanis-runners`) don't ship Node, so `npm` isn't on `PATH` and the step fails with `npm: not found` whenever the job lands on a Node-less runner. Releases currently only succeed when the job happens to run on a runner that already has Node — i.e. they're non-deterministic.

This adds an **unconditional** `actions/setup-node` step before `Semantic Release`, so Node is always present regardless of which runner picks up the job. Node is pinned to `22`, which satisfies semantic-release 25's engine requirement (`^22.14 || >=24.10`).

Follows the existing pattern in this workflow of provisioning missing tooling on the self-hosted pools (Azure CLI, GitHub CLI, Java).

```
Run cycjimmy/semantic-release-action@v6.0.0
Error: Command failed: npm --loglevel error ci --only=prod
/bin/sh: 1: npm: not found
```

## Related Issue

N/A — surfaced from a failing self-hosted release run; no separate tracked issue.

## Testing Instructions

Trigger the release workflow (e.g. `workflow_dispatch` on `_release.yaml`, or a push to `main`) on a self-hosted runner pool (`daedalus` / `arkanis-runners`) and confirm the `Setup Node.js` step runs and the `Semantic Release` step no longer errors with `npm: not found`. A dry-run PR build also exercises the step.

## PR Questionnaire

<details>

### General
- [x] I have kept the scope of the changes limited to the purpose of this PR.
- [x] I have verified consistent behaviour across relevant existing parts of the codebase.
- [x] I have ensured that unrelated code has not been affected or altered by this PR.
- [x] I have not introduced unnecessary or unwanted files, dependencies, or assets.
- [x] I have not included any sensitive information, credentials, or secrets in this PR.
- [x] I accept that my contribution will be rejected if any of my statements are false.
- [x] I have read and agree to the project's [CONTRIBUTING.md](../CONTRIBUTING.md).

### Testing

How did you test your changes?

- [ ] I have added automated tests where applicable.
- [ ] I have tested the changes manually.
- [x] I did not test these changes — validation relies on the workflow run itself (the release step only runs in CI). YAML was parse-validated locally.

### AI Usage

Did you use generative AI tools to assist in creating this PR?

- [x] Yes, I made ***significant*** use of AI tools and certify that:
    - [x] I have reviewed the generated code in detail.
    - [x] I fully understand the generated code.
    - [x] The generated code meets the project's coding standards.
    - [ ] I have tested the generated code to ensure it works as intended — pending the CI release run.
    - [x] I have disclosed clearly which parts of the code were generated by AI tools.
- [ ] Yes, I made ***minor*** use of AI tools (e.g. autocomplete, inline suggestions) and have reviewed the generated code.
- [ ] No, I did not use generative AI tools in this PR.

> Authored by Claude Code (Opus 4.8) on Merlin's behalf; the single-step workflow change was reviewed but not yet exercised by an actual release run.

### Licensing
- [x] I have read and agree to the project's [LICENSE.md](../LICENSE.md).
- [x] I agree for my contributions to be licensed under the project's [LICENSE.md](../LICENSE.md).
- [x] I certify that I hold the necessary rights for my contributions and that they do not infringe on any third-party rights.
</details>

## Additional Notes

This explains why recent nightly/main releases were flaky rather than cleanly failing: the outcome depended on which runner serviced the job. The fix makes it deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
