### PR TITLE
fix: fetch Azure code-signing token on host, not in azure/cli container

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -77,13 +77,16 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Get Azure API Access Token
-        uses: azure/cli@v3
+        # Fetch the code-signing token on the HOST: `az` is installed above
+        # (elstudio/action-install-azure-cli) and azure/login authenticated the host via
+        # OIDC. The azure/cli action runs the command inside its own Docker container
+        # (mcr.microsoft.com/azure-cli) which does NOT inherit the host login, so on the
+        # self-hosted daedalus pool it failed with "Please run 'az login'", yielding an
+        # empty token and a failed signing command. Run az directly on the host instead.
+        # Token is used for Azure Code Signing in scripts/release-12-verify-win64-velopack.sh.
         if: env.ENABLE_CODE_SIGNING
-        with:
-          azcliversion: 'latest'
-          # used for Azure Code Signing in `scripts/release-12-verify-win64-velopack.sh`
-          inlineScript: |
-            echo "AZURE_API_ACCESS_TOKEN=$(az account get-access-token --resource https://codesigning.azure.net --query accessToken --output tsv)" >> $GITHUB_ENV
+        run: |
+          echo "AZURE_API_ACCESS_TOKEN=$(az account get-access-token --resource https://codesigning.azure.net --query accessToken --output tsv)" >> "$GITHUB_ENV"
 
       - name: Setup .NET
         id: setup-dotnet


### PR DESCRIPTION
## Summary

Nightly releases fail at code signing. The release job authenticates the host to Azure with `azure/login` (OIDC — **succeeds**), but fetches the code-signing access token using the `azure/cli` action, which runs its script inside a **Docker container** (`mcr.microsoft.com/azure-cli`). That container doesn't inherit the host's `az login` session, so on the self-hosted `daedalus` pool it fails:

```
Azure CLI login succeeds by using OIDC.           ← host login OK
Starting script execution via docker image mcr.microsoft.com/azure-cli:latest
ERROR: Please run 'az login' to setup account.    ← container has no session
AZURE_API_ACCESS_TOKEN:                            ← empty
...
[FTL] Signing command failed.                      ← jsign got an empty storepass
✘ Failed step "verifyRelease" of plugin "@semantic-release/exec"
```

`az` is already installed on the host (`elstudio/action-install-azure-cli`), so this just fetches the token in a plain host `run:` step that shares the OIDC login. Gate (`if: env.ENABLE_CODE_SIGNING`) unchanged.

**Why it surfaced now:** masked until #613 — the release never reached signing because semantic-release died earlier on `npm: not found`. This is the next layer down.

## Related Issue

N/A — surfaced from the failed nightly release on `main` after #613.

## Testing Instructions

Signing only runs when `ENABLE_CODE_SIGNING` is true (`main` / `release/*` / `ci`), so a normal PR build (dry-run, signing disabled) does **not** exercise it. Validate via the `ci` branch (dry-run **with** signing enabled — runs `verifyRelease`/signing but does not publish) or on `main`. Success = the `Get Azure API Access Token` step populates the token and Velopack packing/signing completes without `[FTL] Signing command failed`.

## PR Questionnaire

<details>

### General
- [x] I have kept the scope of the changes limited to the purpose of this PR.
- [x] I have verified consistent behaviour across relevant existing parts of the codebase.
- [x] I have ensured that unrelated code has not been affected or altered by this PR.
- [x] I have not introduced unnecessary or unwanted files, dependencies, or assets.
- [x] I have not included any sensitive information, credentials, or secrets in this PR.
- [x] I accept that my contribution will be rejected if any of my statements are false.
- [x] I have read and agree to the project's [CONTRIBUTING.md](../CONTRIBUTING.md).

### Testing

How did you test your changes?

- [ ] I have added automated tests where applicable.
- [ ] I have tested the changes manually.
- [x] I did not test these changes yet — signing only runs on `ci`/`main`; needs a dry-run-with-signing validation on the `ci` branch (or a `main` release). YAML was parse-validated locally.

### AI Usage

Did you use generative AI tools to assist in creating this PR?

- [x] Yes, I made ***significant*** use of AI tools and certify that:
    - [x] I have reviewed the generated code in detail.
    - [x] I fully understand the generated code.
    - [x] The generated code meets the project's coding standards.
    - [ ] I have tested the generated code to ensure it works as intended — pending a signing-enabled CI run.
    - [x] I have disclosed clearly which parts of the code were generated by AI tools.
- [ ] Yes, I made ***minor*** use of AI tools (e.g. autocomplete, inline suggestions) and have reviewed the generated code.
- [ ] No, I did not use generative AI tools in this PR.

> Authored by Claude Code (Opus 4.8) on Merlin's behalf; root-caused from the failed `main` release logs.

### Licensing
- [x] I have read and agree to the project's [LICENSE.md](../LICENSE.md).
- [x] I agree for my contributions to be licensed under the project's [LICENSE.md](../LICENSE.md).
- [x] I certify that I hold the necessary rights for my contributions and that they do not infringe on any third-party rights.
</details>

## Additional Notes

**Possible next layer to watch** during validation: the failed run also showed `@semantic-release/github` erroring with `Variable $owner of type String! was provided invalid value` — but that was inside the **`fail`** handler (triggered *by* the signing failure), so it may simply disappear once signing passes. If it persists in the success/publish path, it's a separate `@semantic-release/github` config issue (note `package.json` was removed from the repo in #597, so `repositoryUrl` now resolves from the git remote) and would need its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
