### PR TITLE
fix: vehicle-inventory entities crash search and are not surfaced

### DIFF
--- a/src/Arkanis.Overlay.Components/Shared/GameEntitySearchControls.razor
+++ b/src/Arkanis.Overlay.Components/Shared/GameEntitySearchControls.razor
@@ -187,7 +187,7 @@
             _unassignedEntries = _allEntries.Where(x => x.Type is InventoryEntryBase.EntryType.Virtual).ToArray();
             _unassignedQuantities = Quantity.Aggregate(_unassignedEntries.Select(x => x.Quantity)).ToArray();
 
-            _assignedEntries = _allEntries.Where(x => x is IGameLocatedAt locatedAt && CurrentLocation?.IsOrContains(locatedAt.Location) != false).ToArray();
+            _assignedEntries = _allEntries.Where(x => x.GetPlacementLocation() is { } location && CurrentLocation?.IsOrContains(location) != false).ToArray();
             _assignedQuantities = Quantity.Aggregate(_assignedEntries.Select(x => x.Quantity)).ToArray();
         }
 

--- a/src/Arkanis.Overlay.Components/Shared/GameEntitySearchDetails.razor
+++ b/src/Arkanis.Overlay.Components/Shared/GameEntitySearchDetails.razor
@@ -140,7 +140,7 @@
             var unassigned = allEntries.Where(x => x.Type is InventoryEntryBase.EntryType.Virtual).ToArray();
             _unassignedQuantities = Quantity.Aggregate(unassigned.Select(x => x.Quantity)).ToArray();
 
-            var assigned = allEntries.Where(x => x is IGameLocatedAt locatedAt && CurrentLocation?.IsOrContains(locatedAt.Location) != false).ToArray();
+            var assigned = allEntries.Where(x => x.GetPlacementLocation() is { } location && CurrentLocation?.IsOrContains(location) != false).ToArray();
             _assignedQuantities = Quantity.Aggregate(assigned.Select(x => x.Quantity)).ToArray();
         }
     }

--- a/src/Arkanis.Overlay.Components/Shared/InventoryEntryFilters.razor
+++ b/src/Arkanis.Overlay.Components/Shared/InventoryEntryFilters.razor
@@ -166,7 +166,7 @@
         public IEnumerable<InventoryEntryBase> Filter(IEnumerable<InventoryEntryBase> entries)
             => entries
                 .Where(x => Text is null || x.Entity.Name.MainContent.FullName.Contains(Text, StringComparison.OrdinalIgnoreCase))
-                .Where(x => Location is null || (x is IGameLocatedAt locatedAt && Location.IsOrContains(locatedAt.Location)))
+                .Where(x => Location is null || (x.GetPlacementLocation() is { } placementLocation && Location.IsOrContains(placementLocation)))
                 .Where(x => InventoryList is null || x.List?.Id == InventoryList.Id);
     }
 

--- a/src/Arkanis.Overlay.Domain/Models/Inventory/InventoryEntries.cs
+++ b/src/Arkanis.Overlay.Domain/Models/Inventory/InventoryEntries.cs
@@ -352,3 +352,24 @@ public enum VehicleInventoryType
     Cargo,
     Module,
 }
+
+public static class InventoryEntryExtensions
+{
+    /// <summary>
+    ///     Resolves the physical game location an inventory entry sits at.
+    /// </summary>
+    /// <remarks>
+    ///     Location- and hangar-placed entries expose their location directly via <see cref="IGameLocatedAt" />.
+    ///     Vehicle-placed entries (cargo and modules) are located wherever their containing vehicle is, so they
+    ///     resolve through <see cref="IVehicleInventory.HangarEntry" />. Unplaced (virtual) entries have no location.
+    ///     This lets consumers (e.g. search) treat all placements uniformly instead of only <see cref="IGameLocatedAt" />.
+    /// </remarks>
+    /// <returns>The entry's game location, or <c>null</c> when it is not placed anywhere.</returns>
+    public static IGameLocation? GetPlacementLocation(this InventoryEntryBase entry)
+        => entry switch
+        {
+            IGameLocatedAt locatedAt => locatedAt.Location,
+            IVehicleInventory vehicleInventory => vehicleInventory.HangarEntry.Location,
+            _ => null,
+        };
+}

--- a/src/Arkanis.Overlay.Infrastructure/Data/Mappers/InventoryEntityMapper.cs
+++ b/src/Arkanis.Overlay.Infrastructure/Data/Mappers/InventoryEntityMapper.cs
@@ -135,11 +135,30 @@ internal partial class InventoryEntityMapper(
         [ReferenceHandler] IReferenceHandler referenceHandler
     );
 
+    //? Maps a hangar entry WITHOUT its Modules/Inventory back-references.
+    //  Used exclusively for the required HangarEntry navigation of vehicle-placed entries below.
+    //  Mapperly assigns required members inside the target's object initializer, i.e. BEFORE the
+    //  vehicle entry registers its own reference. If the mapped hangar then walked its Modules/Inventory
+    //  collections (which contain that very vehicle entry) the reference handler could not yet
+    //  de-duplicate it, producing unbounded recursion. Omitting those collections here breaks the cycle;
+    //  when a hangar is instead mapped as a top-level entry its full mapping above is used, and any
+    //  nested vehicle entry resolves back to it through the reference handler.
+    [MapProperty(nameof(HangarInventoryEntryEntity.LocationId), nameof(HangarInventoryEntry.Location))]
+    [MapperIgnoreTarget(nameof(HangarInventoryEntry.IsLoaner))]
+    [MapperIgnoreTarget(nameof(HangarInventoryEntry.Modules))]
+    [MapperIgnoreTarget(nameof(HangarInventoryEntry.Inventory))]
+    private partial HangarInventoryEntry MapAsReference(
+        HangarInventoryEntryEntity bareEntry,
+        [ReferenceHandler] IReferenceHandler referenceHandler
+    );
+
+    [MapProperty(nameof(VehicleModuleEntryEntity.HangarEntry), nameof(VehicleModuleEntry.HangarEntry), Use = nameof(MapAsReference))]
     private partial VehicleModuleEntry Map(
         VehicleModuleEntryEntity bareEntry,
         [ReferenceHandler] IReferenceHandler referenceHandler
     );
 
+    [MapProperty(nameof(VehicleInventoryEntryEntity.HangarEntry), nameof(VehicleInventoryEntry.HangarEntry), Use = nameof(MapAsReference))]
     private partial VehicleInventoryEntry Map(
         VehicleInventoryEntryEntity bareEntry,
         [ReferenceHandler] IReferenceHandler referenceHandler

--- a/src/Arkanis.Overlay.Infrastructure/Services/LocalDatabaseInventoryManager.cs
+++ b/src/Arkanis.Overlay.Infrastructure/Services/LocalDatabaseInventoryManager.cs
@@ -55,9 +55,11 @@ internal class LocalDatabaseInventoryManager(
                    }
 
                    await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-                   var entities = await dbContext.InventoryEntries
-                       .Where(x => x.Quantity.Reference.EntityId == uexId)
-                       .Where(x => x.EntryType == entryType)
+                   var entities = await IncludeVehicleHangarEntries(
+                           dbContext.InventoryEntries
+                               .Where(x => x.Quantity.Reference.EntityId == uexId)
+                               .Where(x => x.EntryType == entryType)
+                       )
                        .ToArrayAsync(cancellationToken);
 
                    return entities
@@ -81,8 +83,10 @@ internal class LocalDatabaseInventoryManager(
                    }
 
                    await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-                   var entities = await dbContext.InventoryEntries
-                       .Where(x => x.Quantity.Reference.EntityId == uexId)
+                   var entities = await IncludeVehicleHangarEntries(
+                           dbContext.InventoryEntries
+                               .Where(x => x.Quantity.Reference.EntityId == uexId)
+                       )
                        .ToArrayAsync(cancellationToken);
 
                    return entities
@@ -234,6 +238,23 @@ internal class LocalDatabaseInventoryManager(
 
         await TriggerChangeAsync();
     }
+
+    /// <summary>
+    ///     Eagerly loads the <see cref="HangarInventoryEntryEntity" /> referenced by vehicle-placed entries
+    ///     (cargo and modules). These filtered queries can return such an entry without the hangar it belongs
+    ///     to, but the mapped domain models (<see cref="VehicleInventoryEntry" />, <see cref="VehicleModuleEntry" />)
+    ///     require a non-null <c>HangarEntry</c> — mapping a bare entry throws and crashes the UI.
+    /// </summary>
+    /// <remarks>
+    ///     This is done with an explicit include rather than a navigation <c>AutoInclude</c> on purpose:
+    ///     <c>HangarEntry</c> sits on a navigation cycle (Hangar → List → Entries → vehicle entry → HangarEntry),
+    ///     and making it auto-included closes that cycle for EF Core's include expansion, which then recurses
+    ///     indefinitely and hangs query compilation. An explicit include loads exactly one hop and terminates.
+    /// </remarks>
+    private static IQueryable<InventoryEntryEntityBase> IncludeVehicleHangarEntries(IQueryable<InventoryEntryEntityBase> query)
+        => query
+            .Include(x => (x as VehicleInventoryEntryEntity)!.HangarEntry)
+            .Include(x => (x as VehicleModuleEntryEntity)!.HangarEntry);
 
     private async Task TriggerChangeAsync()
         => await changeTokenManager.TriggerChangeForAsync<CacheId>();

--- a/tests/Arkanis.Overlay.Infrastructure.UnitTests/Data/Entities/GameEntityFixture.cs
+++ b/tests/Arkanis.Overlay.Infrastructure.UnitTests/Data/Entities/GameEntityFixture.cs
@@ -131,6 +131,15 @@ internal static class GameEntityFixture
         ExternalUexDTOFixture.Commodity3.Code!
     );
 
+    // No dedicated UEX DTO fixture for a vehicle; a synthetic id suffices as long as it is unique
+    // and cached for hydration. Used to exercise vehicle-hangar inventory placement (HangarInventoryEntry).
+    public static GameSpaceShip SpaceShip { get; } = new(
+        90001,
+        "Test Runner",
+        "TRUN",
+        ItemCompany
+    );
+
     public static IGameEntity[] AllEntities
         =>
         [
@@ -151,5 +160,6 @@ internal static class GameEntityFixture
             Commodity1,
             Commodity2,
             Commodity3,
+            SpaceShip,
         ];
 }

--- a/tests/Arkanis.Overlay.Infrastructure.UnitTests/DomainModels/InventoryEntryPlacementLocationTests.cs
+++ b/tests/Arkanis.Overlay.Infrastructure.UnitTests/DomainModels/InventoryEntryPlacementLocationTests.cs
@@ -1,0 +1,56 @@
+namespace Arkanis.Overlay.Infrastructure.UnitTests.DomainModels;
+
+using Arkanis.Overlay.Domain.Models.Inventory;
+using Data.Entities;
+using Shouldly;
+
+/// <summary>
+///     Covers <see cref="InventoryEntryExtensions.GetPlacementLocation" />, which resolves the physical game
+///     location an inventory entry sits at. Vehicle-placed entries (cargo/modules) resolve to their containing
+///     vehicle's location; without this the search view cannot surface them (they are not
+///     <see cref="Domain.Abstractions.Game.IGameLocatedAt" /> like location/hangar entries are).
+/// </summary>
+public class InventoryEntryPlacementLocationTests
+{
+    [Fact]
+    public void Location_Entry_Resolves_To_Its_Own_Location()
+    {
+        var entry = InventoryEntry.CreateAt(GameEntityFixture.Item1, new Quantity(1, Quantity.UnitType.Count), GameEntityFixture.SpaceStation);
+
+        entry.GetPlacementLocation().ShouldBe(GameEntityFixture.SpaceStation);
+    }
+
+    [Fact]
+    public void Hangar_Entry_Resolves_To_Its_Own_Location()
+    {
+        var hangarEntry = InventoryEntry.CreateAt(GameEntityFixture.SpaceShip, GameEntityFixture.SpaceStation);
+
+        hangarEntry.GetPlacementLocation().ShouldBe(GameEntityFixture.SpaceStation);
+    }
+
+    [Fact]
+    public void Vehicle_Cargo_Entry_Resolves_To_Its_Vehicle_Location()
+    {
+        var hangarEntry = InventoryEntry.CreateAt(GameEntityFixture.SpaceShip, GameEntityFixture.SpaceStation);
+        var cargo = InventoryEntry.CreateCargo(GameEntityFixture.Item1, new Quantity(3, Quantity.UnitType.Count), hangarEntry);
+
+        cargo.GetPlacementLocation().ShouldBe(GameEntityFixture.SpaceStation);
+    }
+
+    [Fact]
+    public void Vehicle_Module_Entry_Resolves_To_Its_Vehicle_Location()
+    {
+        var hangarEntry = InventoryEntry.CreateAt(GameEntityFixture.SpaceShip, GameEntityFixture.SpaceStation);
+        var module = InventoryEntry.CreateModule(GameEntityFixture.Item1, new Quantity(1, Quantity.UnitType.Count), hangarEntry);
+
+        module.GetPlacementLocation().ShouldBe(GameEntityFixture.SpaceStation);
+    }
+
+    [Fact]
+    public void Virtual_Entry_Has_No_Placement_Location()
+    {
+        var entry = InventoryEntry.Create(GameEntityFixture.Item1, new Quantity(1, Quantity.UnitType.Count));
+
+        entry.GetPlacementLocation().ShouldBeNull();
+    }
+}

--- a/tests/Arkanis.Overlay.Infrastructure.UnitTests/Services/LocalDatabaseInventoryManagerUnitTests.cs
+++ b/tests/Arkanis.Overlay.Infrastructure.UnitTests/Services/LocalDatabaseInventoryManagerUnitTests.cs
@@ -85,6 +85,53 @@ public class LocalDatabaseInventoryManagerUnitTests(ITestOutputHelper testOutput
     }
 
     [Fact]
+    public async Task Can_Get_Vehicle_Cargo_Entry_For_Item()
+    {
+        // Regression: an item stored in a vehicle's inventory (VehicleInventoryEntry) has a required
+        // HangarEntry reference. When queried via GetEntriesForAsync (e.g. from the search details view),
+        // the HangarEntry navigation must be loaded, otherwise mapping to the domain model throws
+        // ArgumentNullException('HangarEntry') and crashes the Overlay UI.
+        await SetUp();
+
+        var inventoryManager = this.GetRequiredService<LocalDatabaseInventoryManager>();
+
+        var hangarEntry = InventoryEntry.CreateAt(GameEntityFixture.SpaceShip, GameEntityFixture.SpaceStation);
+        await inventoryManager.AddOrUpdateEntryAsync(hangarEntry, TestContext.Current.CancellationToken);
+
+        var cargo = InventoryEntry.CreateCargo(GameEntityFixture.Item1, new Quantity(3, Quantity.UnitType.Count), hangarEntry);
+        await inventoryManager.AddOrUpdateEntryAsync(cargo, TestContext.Current.CancellationToken);
+
+        var entries = await inventoryManager.GetEntriesForAsync(GameEntityFixture.Item1.Id, TestContext.Current.CancellationToken);
+
+        var cargoEntry = entries.SingleOrDefault(x => x.Id == cargo.Id).ShouldNotBeNull();
+        var vehicleEntry = cargoEntry.ShouldBeOfType<VehicleInventoryEntry>();
+        vehicleEntry.HangarEntry.Id.ShouldBe(hangarEntry.Id);
+    }
+
+    [Fact]
+    public async Task Can_Get_Hangar_With_Its_Vehicle_Cargo()
+    {
+        // Complements the search path above: when a hangar is loaded as a top-level entry (as the hangar
+        // view does via GetAllEntriesAsync) its Inventory/Modules must be fully populated. Mapping this
+        // hangar<->cargo reference cycle must terminate (the cargo's HangarEntry is mapped without walking
+        // back into the hangar's collections).
+        await SetUp();
+
+        var inventoryManager = this.GetRequiredService<LocalDatabaseInventoryManager>();
+
+        var hangarEntry = InventoryEntry.CreateAt(GameEntityFixture.SpaceShip, GameEntityFixture.SpaceStation);
+        await inventoryManager.AddOrUpdateEntryAsync(hangarEntry, TestContext.Current.CancellationToken);
+
+        var cargo = InventoryEntry.CreateCargo(GameEntityFixture.Item1, new Quantity(3, Quantity.UnitType.Count), hangarEntry);
+        await inventoryManager.AddOrUpdateEntryAsync(cargo, TestContext.Current.CancellationToken);
+
+        var allEntries = await inventoryManager.GetAllEntriesAsync(TestContext.Current.CancellationToken);
+
+        var loadedHangar = allEntries.OfType<HangarInventoryEntry>().SingleOrDefault(x => x.Id == hangarEntry.Id).ShouldNotBeNull();
+        loadedHangar.Inventory.ShouldContain(x => x.Id == cargo.Id);
+    }
+
+    [Fact]
     public async Task Can_Insert_List()
     {
         await SetUp();


### PR DESCRIPTION
## Summary

Fixes a crash and three related visibility gaps around **items stored in a vehicle's inventory** (cargo and modules).

- **Crash:** searching for an entity stored in a vehicle's inventory crashed the Overlay UI with `ArgumentNullException: Value cannot be null. (Parameter 'HangarEntry')`. The filtered inventory query returned the vehicle entry without loading its containing hangar, which the mapped domain model requires.
- **Surfacing:** once the crash was fixed, vehicle-inventory entries still weren't surfaced — they were filtered out everywhere placements were matched by `IGameLocatedAt`, which vehicle-placed entries don't implement (their location is indirect, via the vehicle). This affected the search-details chip, the search "Manage inventory" badge, and the inventory view's location filter.

The visibility fixes all funnel through one new helper, `InventoryEntryExtensions.GetPlacementLocation`, which resolves an entry's physical location uniformly (direct for location/hangar entries, via the vehicle for cargo/modules, `null` for virtual).

## Related Issue

<!-- Reported via a user support call; no tracked issue. -->

## Testing Instructions

1. Add a vehicle to your hangar, then add an item/commodity into that vehicle's inventory (as cargo).
2. Search for that item in the search bar.
   - **Before:** the Overlay crashes and must be restarted.
   - **After:** no crash; the item's inventory chip and the "Manage inventory" badge both include the vehicle-stored quantity.
3. Open the Inventory view and filter by the location where the vehicle is parked — the vehicle's cargo now appears.
4. Automated: `dotnet test tests/Arkanis.Overlay.Infrastructure.UnitTests` (46 pass, incl. new regression tests).

## PR Questionnaire

<details>

### General
- [x] I have kept the scope of the changes limited to the purpose of this PR.
- [x] I have verified consistent behaviour across relevant existing parts of the codebase.
- [x] I have ensured that unrelated code has not been affected or altered by this PR.
- [x] I have not introduced unnecessary or unwanted files, dependencies, or assets.
- [x] I have not included any sensitive information, credentials, or secrets in this PR.
- [x] I accept that my contribution will be rejected if any of my statements are false.
- [x] I have read and agree to the project's [CONTRIBUTING.md](../CONTRIBUTING.md).

### Testing

How did you test your changes?

- [x] I have added automated tests where applicable.
- [x] I have tested the changes manually.
- [ ] I did not test these changes.

### AI Usage

Did you use generative AI tools to assist in creating this PR?

- [x] Yes, I made ***significant*** use of AI tools and certify that:
    - [x] I have reviewed the generated code in detail.
    - [x] I fully understand the generated code.
    - [x] The generated code meets the project's coding standards.
    - [x] I have tested the generated code to ensure it works as intended.
    - [x] I have disclosed clearly which parts of the code were generated by AI tools.
- [ ] Yes, I made ***minor*** use of AI tools (e.g. autocomplete, inline suggestions) and have reviewed the generated code.
- [ ] No, I did not use generative AI tools in this PR.

### Licensing
- [x] I have read and agree to the project's [LICENSE.md](../LICENSE.md).
- [x] I agree for my contributions to be licensed under the project's [LICENSE.md](../LICENSE.md).
- [x] I certify that I hold the necessary rights for my contributions and that they do not infringe on any third-party rights.
</details>

## Additional Notes

Disclosure: the code in this PR was authored by Claude Code (Opus 4.8), then reviewed and manually verified in the running Overlay by the maintainer.

<details>
<summary>Root cause &amp; per-commit detail</summary>

**Crash — `fix: load HangarEntry for vehicle-placed inventory entries in filtered queries`**
`GetEntriesForAsync` runs a filtered query that can return a `VehicleInventoryEntry`/`VehicleModuleEntry` without its hangar. The domain models require a non-null `HangarEntry`, so Mapperly threw while mapping the bare entry. Two coupled fixes:
- Explicitly `.Include` the `HangarEntry` navigation in the two filtered queries (`IncludeVehicleHangarEntries`). `AutoInclude` is deliberately **not** used: `HangarEntry` sits on a navigation cycle (`Hangar → List → Entries → vehicle entry → HangarEntry`), and auto-including it makes EF Core's include-expansion recurse indefinitely and hang query compilation (verified via a stack dump of the spinning process).
- Map a vehicle entry's `HangarEntry` via a reference-only hangar mapping (`MapAsReference`) that omits the `Modules`/`Inventory` back-references. Mapperly assigns `required` members inside the object initializer, before the vehicle entry registers its own reference, so walking those collections back to the same entry caused unbounded recursion. This also closes a latent hang that would affect the hangar detail view for any vehicle containing cargo. Top-level hangar loads still use the full mapping.

**Surfacing — remaining three commits**
Added `InventoryEntryExtensions.GetPlacementLocation` and used it in place of `x is IGameLocatedAt` filters in:
- the search-details inventory chip,
- the search "Manage inventory" badge count,
- the inventory view's location filter.

`HangarInventoryEntriesView`'s filter was reviewed and left unchanged — its entries are `HangarInventoryEntry` (the vehicles themselves), which already implement `IGameLocatedAt`.

**Tests:** regression tests for the crash path and the hangar-detail mapping path (`LocalDatabaseInventoryManagerUnitTests`), plus 5 cases covering `GetPlacementLocation` across all placement kinds.
</details>
