### PR TITLE
ci: cache NuGet's default folder, not a workspace path

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -45,8 +45,6 @@ on:
         value: ${{ jobs.release.outputs.last_tag }}
 
 env:
-  # https://github.com/actions/setup-dotnet?tab=readme-ov-file#reduce-caching-size
-  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
   REGISTRY: ghcr.io
   # See: https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Credentials/appId/b6acf5c1-f282-4eb0-a3a4-4e87e95fe051/isMSAApp~/false
   # `true` if the current branch is `main`, `release/rc` or `release/stable`
@@ -88,6 +86,10 @@ jobs:
         run: |
           echo "AZURE_API_ACCESS_TOKEN=$(az account get-access-token --resource https://codesigning.azure.net --query accessToken --output tsv)" >> "$GITHUB_ENV"
 
+      # Caches NuGet's default global-packages folder. Do not point NUGET_PACKAGES at the
+      # workspace to shrink it: the cache `version` is a hash of the literal path, and every
+      # daedalus replica has its own workspace, so that split the cache into one namespace per
+      # replica, each ageing on its own until a stale one broke restores outright (ARK-502).
       - name: Setup .NET
         id: setup-dotnet
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -6,10 +6,6 @@ name: .NET Test
 on:
   workflow_call:
 
-env:
-  # https://github.com/actions/setup-dotnet?tab=readme-ov-file#reduce-caching-size
-  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
-
 jobs:
   test:
     runs-on: windows-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,10 +27,6 @@ permissions:
   packages: write       # for publishing packages in repository registry
   id-token: write       # for Azure Code Signing & Credential Federation
 
-env:
-  # https://github.com/actions/setup-dotnet?tab=readme-ov-file#reduce-caching-size
-  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
-
 jobs:
   test:
     name: Tests


### PR DESCRIPTION
> [!WARNING]
> ⚠️ Do not rebase or force-push after creating your PR. ⚠️
> It makes it impossible to keep track of changes and to review them properly.

## Summary

The NuGet cache in the release workflow was keyed to a path that differs on every `daedalus` replica, which silently split it into one namespace per replica. This drops the `NUGET_PACKAGES` override so NuGet's own default folder is what gets cached.

There is no `path:` line to look at, which is what made it hard to spot. `actions/setup-dotnet` with `cache: true` does not cache a fixed location - it asks `dotnet nuget locals --list` where packages live, and `dotnet` honours `NUGET_PACKAGES`. Setting that to `${{ github.workspace }}/.nuget/packages`, as setup-dotnet's own *reduce caching size* note suggests, therefore decided what got cached, and did so by absolute path.

An Actions cache entry is identified by `(key, version, scope)`, and the `version` is a SHA-256 over the literal path strings. Each `daedalus` replica has its own work directory (`RUNNER_WORKDIR=/runner/data/${n}/work`), so that path hashed to a different version per replica. The hit rate halves, and `restore-keys` match only *within* a version - so a replica is never offered the other's fresher entry and each shard ages independently. In PatchWatch one shard went eleven weeks without a write and broke `dotnet tool restore` outright, wedging CI until the entries were deleted by hand.

Three files change, but only `_release.yaml` was actually sharded:

- **`_release.yaml`** runs on `daedalus` and was affected.
- **`_test.yaml`** pins `windows-latest`, where the workspace is always the same, so it never sharded. The override is dropped for consistency and to stop the pattern being copied; it is deliberately not annotated with a self-hosted rationale that does not apply there.
- **`build.yaml`**'s copy was already dead - every job there is a `uses:` call, and workflow-level `env` does not cross into a called workflow.

The first run after this merges is a cold miss by design; the old per-replica namespaces become unreachable and age out.

## Related Issue

Related to ARK-502 (Linear). No GitHub issue.

## Testing Instructions

Nothing to run locally - the change is workflow configuration, and its effect is only observable on the self-hosted pool. On the first `_release.yaml` run after merge, expect `Cache hit - false` and a save at the end. On the run after that, expect a hit, and expect it to hit regardless of which replica picks the job up - which is the behaviour that was broken.

## PR Questionnaire

<details>

### General
- [x] I have kept the scope of the changes limited to the purpose of this PR.
- [x] I have verified consistent behaviour across relevant existing parts of the codebase.
- [x] I have ensured that unrelated code has not been affected or altered by this PR.
- [x] I have not introduced unnecessary or unwanted files, dependencies, or assets.
- [x] I have not included any sensitive information, credentials, or secrets in this PR.
- [x] I accept that my contribution will be rejected if any of my statements are false.
- [x] I have read and agree to the project's [CONTRIBUTING.md](../CONTRIBUTING.md).

### Testing

How did you test your changes?

- [ ] I have added automated tests where applicable.
- [ ] I have tested the changes manually.
- [x] I did not test these changes.

The behaviour only reproduces on the multi-replica self-hosted pool; the mechanism was instead verified against the `@actions/cache` and `actions/setup-dotnet` sources, and against the same fix already landed in PatchWatch#120.

### AI Usage

Did you use generative AI tools to assist in creating this PR?

- [x] Yes, I made ***significant*** use of AI tools and certify that:
    - [x] I have reviewed the generated code in detail.
    - [x] I fully understand the generated code.
    - [x] The generated code meets the project's coding standards.
    - [ ] I have tested the generated code to ensure it works as intended.
    - [x] I have disclosed clearly which parts of the code were generated by AI tools.
- [ ] Yes, I made ***minor*** use of AI tools (e.g. autocomplete, inline suggestions) and have reviewed the generated code.
- [ ] No, I did not use generative AI tools in this PR.

The whole change was authored by Claude Code and reviewed before opening.

### Licensing
- [x] I have read and agree to the project's [LICENSE.md](../LICENSE.md).
- [x] I agree for my contributions to be licensed under the project's [LICENSE.md](../LICENSE.md).
- [x] I certify that I hold the necessary rights for my contributions and that they do not infringe on any third-party rights.
</details>

## Additional Notes

Part of an org-wide audit for this defect (ARK-502): all 37 repositories enumerated and every workflow under `.github/**` read. Six needed a change. The central `ci` repository carries the same fix and reaches seven further repositories through its floating `@v1` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BXGbwVXcKnvByvcuJssuR
